### PR TITLE
flamegraph could escape some illegal XML characters

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -172,6 +172,8 @@ my $time = 0;
 foreach (sort @Data) {
 	chomp;
 	my ($stack, $samples) = (/^(.*)\s+(\d+)$/);
+	$stack =~ s/</(/g;
+	$stack =~ s/>/)/g;
 	$stack = ",$stack";
 	next unless defined $samples;
 	flow($last, $stack, $time);


### PR DESCRIPTION
This is needed for the node ustack helper, which emits '<' and '>', which corrupt the SVG file.
