### PR TITLE
handle C++ function names better

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -240,6 +240,9 @@ foreach my $id (keys %Node) {
 		$info = "all samples ($samples samples, 100%)";
 	} else {
 		my $pct = sprintf "%.2f", ((100 * $samples) / $timemax);
+		$func =~ s/&/&amp;/g;
+		$func =~ s/</&lt;/g;
+		$func =~ s/>/&gt;/g;
 		$info = "$func ($samples samples, $pct%)";
 	}
 	$im->filledRectangle($x1, $y1, $x2, $y2, color("hot"), 'rx="2" ry="2" onmouseover="s(' . "'$info'" . ')" onmouseout="c()"');

--- a/stackcollapse.pl
+++ b/stackcollapse.pl
@@ -76,6 +76,8 @@ foreach (<>) {
 	my $frame = $_;
 	$frame =~ s/^\s*//;
 	$frame =~ s/\+.*$//;
+	# Remove arguments from C++ function names.
+	$frame =~ s/(..)[(<].*/$1/;
 	$frame = "-" if $frame eq "";
 	unshift @stack, $frame;
 }


### PR DESCRIPTION
This change does two things:
- Escapes XML meta-characters while emitting the SVG. You need this because C++ function names can have an "&".
- Removes function and template arguments, as long as they're not one of the first two characters of the function name. This exception exists because the Node ustack helper emits lines with "<<" and "((" prefixes.
