### PR TITLE
Missed a comma

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -174,7 +174,7 @@ foreach (sort @Data) {
 	my ($stack, $samples) = (/^(.*)\s+(\d+)$/);
 	$stack =~ s/</(/g;
 	$stack =~ s/>/)/g;
-	$stack = ",$stack";
+	$stack = ";$stack";
 	next unless defined $samples;
 	flow($last, $stack, $time);
 	$time += $samples;


### PR DESCRIPTION
`flamegraph.pl` still prefixes each line with a comma instead of a semicolon.
