### PR TITLE
Use <g> to simplify SVG and fix styling. Make functions clickable etc.

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -143,6 +143,8 @@ SVG
 		if ($attr->{href}) {
 			my @a_attr;
 			push @a_attr, sprintf qq/xlink:href="%s"/, $attr->{href} if $attr->{href};
+                        # default target=_top else links will open within SVG <object>
+			push @a_attr, sprintf qq/target="%s"/, $attr->{target} || "_top";
 			push @a_attr, $attr->{a_extra}                           if $attr->{a_extra};
 			$self->{svg} .= sprintf qq/<a %s>/, join(' ', @a_attr);
 		}


### PR DESCRIPTION
Place each rect and text pair into a g block.
Replace the duplicated rect and text onmouseover with a single g onmouseover.
This reduces the size of the SVG file. It also fixes the loss of the black border when mousing over the text.

An external file can be used to specify attributes for individual functions. So, for example, functions can now be given links.

(They can't be given specific colors via this mechanism, at least not currently, because the colour of the <g> is overridden by the colour of the <rect>. YAGNI applies for now.)
