### PR TITLE
Allow floating point values

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -294,7 +294,7 @@ foreach my $id (keys %Node) {
 	my $y1 = $imageheight - $ypad2 - ($depth + 1) * $frameheight + 1;
 	my $y2 = $imageheight - $ypad2 - $depth * $frameheight;
 
-	my $samples = $etime - $stime;
+	my $samples = sprintf "%.0f", $etime - $stime;
         (my $samples_txt = $samples) # add commas per perlfaq5
             =~ s/(^[-+]?\d+?(?=(?>(?:\d{3})+)(?!\d))|\G\d{3}(?=\d))/$1,/g;
 


### PR DESCRIPTION
"be generous in what you accept"

On some platforms the timing data from NYTProf is in tenths of a microsecond.
