### PR TITLE
Add --factor option to scale the presented values.

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -249,7 +249,8 @@ warn "Ignored $ignored lines with invalid format\n" if $ignored;
 die "ERROR: No stack counts found\n" unless $time;
 
 if ($timemax and $timemax < $time) {
-    warn "Specified --total $timemax is less than actual total $time, so ignored\n";
+    warn "Specified --total $timemax is less than actual total $time, so ignored\n"
+        if $timemax/$time > 0.02; # only warn is significant (e.g., not rounding etc)
     undef $timemax;
 }
 $timemax ||= $time;


### PR DESCRIPTION
The flamegraph processing requires the addition of many values.
Using floating-point values causes cumulative errors. These are
most noticable when --total is used because otherwise the graph
self-scales to the width.

This patch adds a --factor option that scales the presented values.
So instead of providing floating point values in the data, the data can
be provided as integers and the result scaled to suit using --factor.

p.s The problem with floats in severe enough that I'd recommend removing
support for them. Just change the regex back to \d+.
