### PR TITLE
Fixups for stackcollapse-perf

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -75,13 +75,17 @@ foreach (<>) {
 
 	# Note the details skipped below, and customize as desired
 
-	next if m/:.*:/;	# skip summary lines
+	if (m/:.*:\s$/) {
+		# skip summary lines
+		next;
+	}
 
-	if (/^\s*\w+ (\w+) (\S+)/) {
+	if (/^\s*\w+\s*(.+) (\S+)/) {
 		my ($func, $mod) = ($1, $2);
-		next if $func =~ /\(/;		# skip process names
-		next unless $mod =~ /kernel/;	# skip non-kernel
+		next if $func =~ /^\(/;		# skip process names
 		unshift @stack, $func;
+	} else {
+		warn "Unrecognized line: $_";
 	}
 }
 


### PR DESCRIPTION
This fixes handling of function names with '::' involved, which
show up in C++ if you pass the perf script output through
demangling prior to stackcollapse-perf.

Also disables the skipping of non-kernel code -- perf is equally
useful for profiling user applications.
