### PR TITLE
stackcollapse-perf: fix skipping of summary lines for processes with cus...

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -75,7 +75,7 @@ foreach (<>) {
 
 	# Note the details skipped below, and customize as desired
 
-	if (m/:.*:\s$/) {
+	if (m/.*:\s$/) {
 		# skip summary lines
 		next;
 	}


### PR DESCRIPTION
...tom names

In one of my applications which uses prctl() to set readable thread names,
I have perf script output that looks like:

foobar [worker] 21332 cycles:
                  67e2f0 my_func
                  64138b my_other_func
                  ...

This confused stackcollapse-perf because there weren't two ':' in the summary
line. This patch changes the regex to just look for lines ending in ':' as
summaries.
