### PR TITLE
flamegraph.pl: fixed the sign of the delta percentage when --negate is specified

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -797,8 +797,9 @@ while (my ($id, $node) = each %Node) {
 		unless (defined $delta) {
 			$info = "$escaped_func ($samples_txt $countname, $pct%)";
 		} else {
-			my $deltapct = sprintf "%.2f", ((100 * $delta) / ($timemax * $factor));
-			$deltapct = $delta > 0 ? "+$deltapct" : $deltapct;
+			my $d = $negate ? -$delta : $delta;
+			my $deltapct = sprintf "%.2f", ((100 * $d) / ($timemax * $factor));
+			$deltapct = $d > 0 ? "+$deltapct" : $deltapct;
 			$info = "$escaped_func ($samples_txt $countname, $pct%; $deltapct%)";
 		}
 	}


### PR DESCRIPTION
Right now, when `--negate` is specified, the delta percentage shown is something like "+0.80%" even when the color is blue (reduction in time).