### PR TITLE
stackcollapse-perf.pl reads either from STDIN or first argument.

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -76,7 +76,7 @@ GetOptions( 'inline' => \$show_inline,
             'context' => \$show_context)
 or die("Error in command line arguments\n");
 
-foreach (<STDIN>) {
+foreach (<>) {
 	if(/^# cmdline.+\.\.(\S+)( .+|$)/) {
 		$the_pname = $1;
 	}


### PR DESCRIPTION
All other stackcollapse* already do the same.