### PR TITLE
Don't strip objective-c categories

### DIFF
--- a/stackcollapse.pl
+++ b/stackcollapse.pl
@@ -85,7 +85,7 @@ foreach (<>) {
 	$frame =~ s/\+[^+]*$// unless $includeoffset;
 
 	# Remove arguments from C++ function names:
-	$frame =~ s/(..)[(<].*/$1/;
+	$frame =~ s/(::.*)[(<].*/$1/;
 
 	$frame = "-" if $frame eq "";
 	unshift @stack, $frame;


### PR DESCRIPTION
Just playing around with the flame graph and noticed that objective-c categories were being stripped.   This is a simple regex fix that ensures that the class delimiter (::) for C++ is present before stripping the arguments and template information.   Here's an example objective-c category:

```
UIKit`-[UIView(Internal) _addSubview:positioned:relativeTo:]+0x644
```
This was getting stripped to:
```
UIKit`-[UIView
```