### PR TITLE
For Instruments output capture the "Self" value rather than the "Running Time" value

### DIFF
--- a/stackcollapse-instruments.pl
+++ b/stackcollapse-instruments.pl
@@ -14,7 +14,7 @@ my @stack = ();
 <>;
 foreach (<>) {
 	chomp;
-	/(\d+)\.\d+ms[^,]+,\d+,\s+,(\s*)(.+)/ or die;
+	/\d+\.\d+ms[^,]+,(\d+),\s+,(\s*)(.+)/ or die;
 	my $func = $3;
 	my $depth = length ($2);
 	$stack [$depth] = $3;


### PR DESCRIPTION
This fixes an issue of cascading call times that caused the flamegraph output to incorrectly visually represent the time spent in all parts of the stack.

This bug can be reproduced in practice but clearly seen in the example posted on https://schani.wordpress.com/2012/11/16/flame-graphs-for-instruments/.
I suspect in that example the time spent in "mono_gc_alloc_obj" is actually fairly similar to that in "collect_nursery", however the output reflects a 142:66 ratio.

This issue is caused because flamegraph.pl expects individual time/samples within single stack frames, not a total value for all child stack frames.

The 3rd "Self" value in the Instruments output is the former, so swapping to that value reflects visually the correct time spent in each stack frame.