### PR TITLE
Support function names including '('

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -656,7 +656,7 @@ my $inc = <<INC;
 		var r = find_child(e, "rect");
 		var t = find_child(e, "text");
 		var w = parseFloat(r.attributes["width"].value) -3;
-		var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)/,"");
+		var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)\$/,"");
 		t.attributes["x"].value = parseFloat(r.attributes["x"].value) +3;
 		
 		// Smaller than this size won't fit anything

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -212,7 +212,12 @@ foreach (<>) {
 		if ($tidy_generic) {
 			$func =~ s/;/:/g;
 			$func =~ tr/<>//d;
-			$func =~ s/[^\.]\(.*//;
+			if ($func !~ m/\.\(.*\)\./) {
+				# This doesn't look like a Go method name (such as
+				# "net/http.(*Client).Do"), so everything after the first open
+				# paren is just noise.
+				$func =~ s/\(.*//;
+			}
 			# now tidy this horrible thing:
 			# 13a80b608e0a RegExp:[&<>\"\'] (/tmp/perf-7539.map)
 			$func =~ tr/"\'//d;

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -212,7 +212,7 @@ foreach (<>) {
 		if ($tidy_generic) {
 			$func =~ s/;/:/g;
 			$func =~ tr/<>//d;
-			$func =~ s/\(.*//;
+			$func =~ s/[^\.]\(.*//;
 			# now tidy this horrible thing:
 			# 13a80b608e0a RegExp:[&<>\"\'] (/tmp/perf-7539.map)
 			$func =~ tr/"\'//d;


### PR DESCRIPTION
Go (golang.org) function names include '(' and ')' characters for functions
representing methods on types. For example, the function named
`net/http.(*liveSwitchReader).Read` is for the "Read" method attached to a
pointer to a "liveSwitchReader" value in the package "net/http".

The output of `perf script` for samples of that function look as follows:

    4f4e61 net/http.(*liveSwitchReader).Read (/path/to/binary)

Go 1.5 and above support full stack call graphs in perf_events when programs
are compiled with a toolchain that's built with GOEXPERIMENT=framepointer.