### PR TITLE
Fixes and minor improvements for flamegraph + stack collapse

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -120,7 +120,7 @@ USAGE: $0 [options] infile > outfile.svg\n
 	--countname   # count type label (default "samples")
 	--nametype    # name type label (default "Function:")
 	--colors      # set color palette. choices are: hot (default), mem, io,
-	              # java, js, red, green, blue, yellow, purple, orange
+	              # java, js, perl, red, green, blue, yellow, purple, orange
 	--hash        # colors are keyed by function name hash
 	--cp          # use consistent palette (palette.map)
 	--reverse     # generate stack-reversed flame graph
@@ -335,6 +335,20 @@ sub color {
 			$type = "yellow";
 		} elsif ($name =~ m:/:) {	# Java (match "/" in path)
 			$type = "green"
+		} elsif ($name =~ m: \[k\]:) {	# kernel
+			$type = "purple"
+		} else {			# system
+			$type = "red";
+		}
+		# fall-through to color palettes
+	}
+	if (defined $type and $type eq "perl") {
+		if ($name =~ /::/) {		# C++
+			$type = "yellow";
+		} elsif ($name =~ m:Perl: or $name =~ m:\.pl:) {	# Perl
+			$type = "green";
+		} elsif ($name =~ m: \[k\]:) {	# kernel
+			$type = "purple"
 		} else {			# system
 			$type = "red";
 		}
@@ -349,6 +363,8 @@ sub color {
 			$type = "aqua"
 		} elsif ($name =~ m/^ $/) {	# Missing symbol
 			$type = "green"
+		} elsif ($name =~ m: \[k\]:) {	# kernel
+			$type = "purple"
 		} else {			# system
 			$type = "red";
 		}

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -429,7 +429,7 @@ sub color_map {
 	if (exists $palette_map{$func}) {
 		return $palette_map{$func};
 	} else {
-		$palette_map{$func} = color($colors);
+		$palette_map{$func} = color($colors, $hash, $func);
 		return $palette_map{$func};
 	}
 }

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -72,7 +72,7 @@ sub remember_stack {
 	my ($stack, $count) = @_;
 	$collapsed{$stack} += $count;
 }
-
+my $annotate_kernel = 0; # put an annotation on kernel function
 my $include_pname = 1;	# include process names in stacks
 my $include_pid = 0;	# include process ID with process name
 my $include_tid = 0;	# include process & thread ID with process name
@@ -85,12 +85,14 @@ my $show_context = 0;
 GetOptions('inline' => \$show_inline,
            'context' => \$show_context,
            'pid' => \$include_pid,
+           'kernel' => \$annotate_kernel,
            'tid' => \$include_tid)
 or die <<USAGE_END;
 USAGE: $0 [options] infile > outfile\n
 	--pid		# include PID with process names [1]
 	--tid		# include TID and PID with process names [1]
 	--inline	# un-inline using addr2line
+	--kernel	# annotate kernel functions with a [k]
 	--context	# include source context from addr2line\n
 [1] perf script must emit both PID and TIDs for these to work; eg:
 	perf script -f comm,pid,tid,cpu,time,event,ip,sym,dso,trace
@@ -201,7 +203,7 @@ foreach (<>) {
 	# stack line
 	} elsif (/^\s*(\w+)\s*(.+) \((\S*)\)/) {
 		my ($pc, $func, $mod) = ($1, $2, $3);
-
+		$func.=" [k]" if ($annotate_kernel == 1 && $mod =~ m/kernel.kall/);
 		if ($show_inline == 1 && index($mod, $target_pname) != -1) {
 			unshift @stack, inline($pc, $mod);
 			next;


### PR DESCRIPTION
Add a new "perl" color, allow to annotate kernel functions and have them displayed when using color groups like "perl", "java" or others