### PR TITLE
Support floating point numbers in instruments CSV

### DIFF
--- a/stackcollapse-instruments.pl
+++ b/stackcollapse-instruments.pl
@@ -14,7 +14,7 @@ my @stack = ();
 <>;
 foreach (<>) {
 	chomp;
-	/\d+\.\d+ms[^,]+,(\d+),\s+,(\s*)(.+)/ or die;
+	/\d+\.\d+ms[^,]+,(\d+(?:\.\d*)?),\s+,(\s*)(.+)/ or die;
 	my $func = $3;
 	my $depth = length ($2);
 	$stack [$depth] = $3;


### PR DESCRIPTION
Hi!

What happened:
- I'm using Instruments with a Time Profiler
- I set the sample interval to 40 microseconds instead of the default of 1 ms
- I exported the track in order to make a flamegraph of it
- The resulting CSV contained Self column values that are sometimes floating point fractional numbers of ms.
- When I ran stackcollapse-instruments.pl on it, I got this error: `Died at ./stackcollapse-instruments.pl line 17, <> line 214.`

The problem appears to be that the regex on line 17 does not expect floating point numbers in the Self column.

Since it looks like [floating point numbers are totally supported in FlameGraph](https://github.com/brendangregg/FlameGraph/commit/54bede2f7d7f2c248f9f8ec8a0459ae7fbc69d9f), I modified the regex to account for the potential of these numbers.

Here's a sample of Instruments CSV data that returns an error when running `stackcollapse-instruments.pl` on it before this change and does not after:

```
Running Time,Self (ms),,Symbol Name
14265.9ms   99.9%,0, ,start
14265.8ms   99.9%,0, , __rust_try
14265.8ms   99.9%,0, ,  sys_common::unwind::try::try_fn::h15411707225561299101
14264.8ms   99.9%,3686.039999999954, ,   profiling::main
```

Please let me know if there are any improvements I can make to this and I am happy to do so!! :heart: :heart: :heart: 