### PR TITLE
stackcollapse-perf.pl: Use module name if function name is unknown

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -209,6 +209,12 @@ while (defined($_ = <>)) {
 			next;
 		}
 
+		if ($func eq "[unknown]" && $mod ne "[unknown]") { # use module name instead, if known
+			$func = $mod;
+			$func =~ s/.*\///;
+			$func = "\[$func\]";
+		}
+
 		next if $func =~ /^\(/;		# skip process names
 
 		if ($tidy_generic) {


### PR DESCRIPTION
Strips any leading path from the module name first, and adds
square brackets to indicate it is a module.

Better some context, than none at all.