### PR TITLE
Support addr2line with java for jni/jvm.so calls

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -203,9 +203,9 @@ while (defined($_ = <>)) {
 	# stack line
 	} elsif (/^\s*(\w+)\s*(.+) \((\S*)\)/) {
 		my ($pc, $func, $mod) = ($1, $2, $3);
-		$func.="_[k]" if ($annotate_kernel == 1 && $mod =~ m/kernel.kall/);
-		if ($show_inline == 1 && index($mod, $target_pname) != -1) {
-			unshift @stack, inline($pc, $mod);
+		$func.="_[k]" if ($annotate_kernel == 1 && $mod =~ m/kernel\./);
+		if ($show_inline == 1 && $mod !~ m/(perf-\d+.map|kernel\.|\[[^\]]+\])/) {
+		        unshift @stack, inline($pc, $mod);
 			next;
 		}
 


### PR DESCRIPTION
I wanted to use addr2line to get details on non-java calls.  This patch simply skips perf-map and [] mod strings from entering the inline function.

Example of the output is [here](https://gist.github.com/tjake/761ba2f22bf280b187dc9c43be291be3)