### PR TITLE
differential graphs: make neutral slightly gray.

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -444,6 +444,11 @@ sub color_scale {
 	} elsif ($value < 0) {
 		$r = $g = int(210 * ($max + $value) / $max);
 	}
+	while ($r > 240 && $b > $240) {
+		$r--;
+		$g--;
+		$b--;
+	}
 	return "rgb($r,$g,$b)";
 }
 


### PR DESCRIPTION
If you plot a differential flame graph against a white background it can look
really weird if there's a lot of neutral frames, because they'll be totally
white too.  This will make them slightly gray instead.
