### PR TITLE
Made stack-collapse work with newer perf.

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -236,6 +236,7 @@ while (defined($_ = <>)) {
 				# now tidy this horrible thing:
 				# 13a80b608e0a RegExp:[&<>\"\'] (/tmp/perf-7539.map)
 				$func =~ tr/"\'//d;
+                $func =~ s/\+0x[\da-f]+//;
 				# fall through to $tidy_java
 			}
 


### PR DESCRIPTION
Perf script has modified output to include an offset for the function
in the call stack. This adds a regex to strip that so that stacks
can collapse properly, again.