### PR TITLE
Use lstat instead of stat to not count size of symbolic link targets

### DIFF
--- a/files.pl
+++ b/files.pl
@@ -31,7 +31,7 @@ my $dir = $ARGV[0];
 find(\&wanted, $dir);
 
 sub wanted {
-	my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size) = stat($_);
+	my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size) = lstat($_);
 	return unless defined $size;
 	my $path = $File::Find::name;
 	$path =~ tr/\//;/;		# delimiter


### PR DESCRIPTION
When we use the files.pl script on e.g. /usr/lib, it would show
an excessively large size for this folder, since it contains many
symlinks. The `stat` syscall gives the size of the symlink target.
By using `lstat` instead, we get the size of the symlink itself.
