### PR TITLE
Recurse into all paths passed to files.pl

### DIFF
--- a/files.pl
+++ b/files.pl
@@ -21,14 +21,16 @@ sub usage {
 	print STDERR "Intended to be piped to flamegraph.pl. Full example:\n";
 	print STDERR "   $0 /Users | flamegraph.pl " .
 	    "--hash --countname=bytes > files.svg\n";
+	print STDERR "   $0 /usr /home /root /etc | flamegraph.pl " .
+	    "--hash --countname=bytes > files.svg\n";
 	exit 1;
 }
 
 usage() if @ARGV == 0 or $ARGV[0] eq "--help" or $ARGV[0] eq "-h";
 
-my $dir = $ARGV[0];
-
-find(\&wanted, $dir);
+foreach my $dir (@ARGV) {
+    find(\&wanted, $dir);
+}
 
 sub wanted {
 	my ($dev,$ino,$mode,$nlink,$uid,$gid,$rdev,$size) = stat($_);


### PR DESCRIPTION
The script used to ignore all but the first CLI argument. Now,
we loop over ARGV and recurse into all paths. This makes it possible
to check the size of multiple folders in the root filesystem in one
go, excluding others that may live e.g. on another partition:

   files.pl /root /var /boot /etc /usr