### PR TITLE
Interpret input as UTF-8

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -80,6 +80,8 @@ use strict;
 
 use Getopt::Long;
 
+use open qw(:std :utf8);
+
 # tunables
 my $encoding;
 my $fonttype = "Verdana";


### PR DESCRIPTION
Using the pragma open option, we can interpret both stdin and input
files as UTF-8 without having to explicitly open them first.