### PR TITLE
Allow horizontal axis to be ordered by call site

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -70,6 +70,7 @@
 #
 # CDDL HEADER END
 #
+# 08-Jun-2017	Guus Sliepen	Strip call site prefixes.
 # 11-Oct-2014	Adrien Mahieux	Added zoom.
 # 21-Nov-2013   Shawn Sterling  Added consistent palette file option
 # 17-Mar-2013   Tim Bunce       Added options and more tunables.
@@ -631,7 +632,10 @@ while (my ($id, $node) = each %Node) {
 		delete $Node{$id};
 		next;
 	}
-	$depthmax = $depth if $depth > $depthmax;
+
+	if (substr($func, -1) ne "+") {
+		$depthmax = $depth if $depth > $depthmax;
+	}
 }
 
 # draw canvas, and embed interactive JavaScript program
@@ -991,9 +995,12 @@ if ($palette) {
 
 # draw frames
 while (my ($id, $node) = each %Node) {
-	my ($func, $depth, $etime) = split ";", $id;
+	my ($pcfunc, $depth, $etime) = split ";", $id;
 	my $stime = $node->{stime};
 	my $delta = $node->{delta};
+
+	my ($pc, $func) = ($pcfunc =~ /(\w*\+)?(.*)/);
+	next if (not $func) and $pc;
 
 	$etime = $timemax if $func eq "" and $depth == 0;
 


### PR DESCRIPTION
FlameGraph is a very nice tool. However, I noticed that within one layer, functions are ordered alphabetically. I thought it would be better to order them in the same order as they are called.

This commit adds the option --call-site to stackcollapse-perf.pl, which will
prefix each function name with its call site. This has two effects:
functions at the same depth are no longer sorted alphabetically, but
rather according to where in the parent function they are called. It
also distinguishes when the same function is called from different call
sites. In flamegraph.pl, the call site prefixes are removed from the
output.

It also adds a dummy call site on the top of the stack, to be able to distinguish where a parent function is spending time itself when it is not calling any other function. These dummy entries are removed from the output, but will ensure the empty space is also ordered as expected.