### PR TITLE
use existing AGENT_HOME environment variable if present

### DIFF
--- a/jmaps
+++ b/jmaps
@@ -26,7 +26,7 @@
 # 20-Feb-2017      "      "     Added -u for unfoldall.
 
 JAVA_HOME=${JAVA_HOME:-/usr/lib/jvm/java-8-oracle}
-AGENT_HOME=/usr/lib/jvm/perf-map-agent  # from https://github.com/jvm-profiling-tools/perf-map-agent
+AGENT_HOME=${AGENT_HOME:-/usr/lib/jvm/perf-map-agent}  # from https://github.com/jvm-profiling-tools/perf-map-agent
 debug=0
 
 if [[ "$USER" != root ]]; then


### PR DESCRIPTION
This changes the jmaps script to use the AGENT_HOME variable found in the environment.