### PR TITLE
Remove non-utf-8 characters from source code

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -1103,7 +1103,7 @@ while (my ($id, $node) = each %Node) {
 
 	my $chars = int( ($x2 - $x1) / ($fontsize * $fontwidth));
 	my $text = "";
-	if ($chars >= 3) { # room for one char plus two dots
+	if ($chars >= 3) { # room for one char plus two dots
 		$func =~ s/_\[[kwij]\]$//;	# strip any annotation
 		$text = substr $func, 0, $chars;
 		substr($text, -2, 2) = ".." if $chars < length $func;


### PR DESCRIPTION
[This is a tiny PR -- literally a one character diff -- to fix a unicode encoding issue in `flamegraph.pl`.]

Apparently commit 514750fe83710a080436cb2bd769047241845cc8 accidentally introduced two "extended" ascii bytes in a comment, making `flamegraph.pl` no longer `utf-8` compliant.  This PR replaces them with an ordinary space character (`0x20`).

The issue is on line 1106:
```
	if ($chars >= 3) { # room for one char plus two dots
                            ^
                            |
                             `--- Not a utf-8 space!
```

As far as I can tell, every other byte in the code is already valid `utf-8`.

(FWIW, I discovered this when attempting to install `flamegraph.pl` in a Python package via `setuptools`.  Apparently it chokes on non-`utf-8` text.)