### PR TITLE
Add support for jmaps in containers

### DIFF
--- a/jmaps
+++ b/jmaps
@@ -88,17 +88,16 @@ for pid in $(pgrep -x java); do
 			java_home=$($nsenter jrunscript -e 'java.lang.System.out.println(java.lang.System.getProperty("java.home"));')
 		fi
 
-		cat $AGENT_JAR | $nsenter dd status=none of=$tmpfile
-		$nsenter mv $tmpfile /tmp/attach-main.jar
+		cp $AGENT_JAR /proc/$pid/root/$tmpfile
+		mv /proc/$pid/root/$tmpfile /proc/$pid/root/tmp/attach-main.jar
 
-		cat $AGENT_HOME/libperfmap.so | $nsenter dd status=none of=$tmpfile
-		$nsenter mv $tmpfile /tmp/libperfmap.so
+		cp $AGENT_HOME/libperfmap.so /proc/$pid/root/$tmpfile
+		mv /proc/$pid/root/$tmpfile /proc/$pid/root/tmp/libperfmap.so
 
 		$nsenter sh -c "cd /tmp; java -Xms32m -Xmx128m -cp attach-main.jar:$java_home/../lib/tools.jar net.virtualvoid.perf.AttachOnce $container_pid $opts"
 
-		$nsenter cat /tmp/perf-$container_pid.map > $tmpfile
+		mv /proc/$pid/root/tmp/perf-$container_pid.map $tmpfile
 		mv $tmpfile $mapfile
-		$nsenter rm /tmp/perf-$container_pid.map
 	else
 		cmd="cd $AGENT_OUT; $JAVA_HOME/bin/java -Xms32m -Xmx128m -cp $AGENT_JAR:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $pid $opts"
 		(( debug )) && echo $cmd

--- a/jmaps
+++ b/jmaps
@@ -81,7 +81,7 @@ for pid in $(pgrep -x java); do
 		tmpfile=$(mktemp -u)
 
 		container_pid=$(awk -F: '$1 == "NSpid" { print $2 }' /proc/$pid/status | awk '{ print $2 }')
-		nsenter="sudo nsenter --target $pid --setuid $user --setgid $(sudo nsenter --target $pid --mount --pid id -g $user) --mount --pid"
+		nsenter="nsenter --target $pid --setuid $user --setgid $(nsenter --target $pid --mount --pid id -g $user) --mount --pid"
 
 		java_home=$(awk -F= 'BEGIN { RS = "\0" } $1 == "JAVA_HOME" { print $2 }' /proc/$pid/environ)
 		if [[ $java_home == "" ]]; then

--- a/jmaps
+++ b/jmaps
@@ -72,25 +72,54 @@ for pid in $(pgrep -x java); do
 	mapfile=/tmp/perf-$pid.map
 	[[ -e $mapfile ]] && rm $mapfile
 
-	cmd="cd $AGENT_OUT; $JAVA_HOME/bin/java -Xms32m -Xmx128m -cp $AGENT_JAR:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $pid $opts"
-	(( debug )) && echo $cmd
-
 	user=$(ps ho user -p $pid)
-	if [[ "$user" != root ]]; then
-		if [[ "$user" == [0-9]* ]]; then
-			# UID only, run sudo with #UID:
-			cmd="sudo -u '#'$user sh -c '$cmd'"
+
+	container=$(cat /proc/$pid/cgroup | grep :/docker/ | awk -F/ '{ print $NF }' | head -n1)
+	if [[ $container != "" ]]; then
+		echo "Prorcess $pid is in container $container"
+
+		tmpfile=$(mktemp -u)
+
+		container_pid=$(cat /proc/$pid/status | grep ^NSpid | awk '{ print $NF }')
+		nsenter="sudo nsenter --target $pid --setuid $user --setgid $(sudo nsenter --target $pid --mount --pid id -g $user) --mount --pid"
+
+		java_home=$(sudo cat /proc/$pid/environ | xargs --null --max-args=1 | grep ^JAVA_HOME | awk -F= '{ print $2 }')
+		if [[ $java_home == "" ]]; then
+			java_home=$($nsenter jrunscript -e 'java.lang.System.out.println(java.lang.System.getProperty("java.home"));')
+		fi
+
+		cat $AGENT_JAR | $nsenter dd status=none of=$tmpfile
+		$nsenter mv $tmpfile /tmp/attach-main.jar
+
+		cat $AGENT_HOME/libperfmap.so | $nsenter dd status=none of=$tmpfile
+		$nsenter mv $tmpfile /tmp/libperfmap.so
+
+		$nsenter sh -c "cd /tmp; java -Xms32m -Xmx128m -cp attach-main.jar:$java_home/../lib/tools.jar net.virtualvoid.perf.AttachOnce $container_pid $opts"
+
+		$nsenter cat /tmp/perf-$container_pid.map > $tmpfile
+		mv $tmpfile $mapfile
+		$nsenter rm /tmp/perf-$container_pid.map
+	else
+		cmd="cd $AGENT_OUT; $JAVA_HOME/bin/java -Xms32m -Xmx128m -cp $AGENT_JAR:$JAVA_HOME/lib/tools.jar net.virtualvoid.perf.AttachOnce $pid $opts"
+		(( debug )) && echo $cmd
+
+		if [[ "$user" != root ]]; then
+			if [[ "$user" == [0-9]* ]]; then
+				# UID only, run sudo with #UID:
+				cmd="sudo -u '#'$user sh -c '$cmd'"
+			else
+				cmd="sudo -u $user sh -c '$cmd'"
+			fi
+		fi
+
+		echo "Mapping PID $pid (user $user):"
+		if (( debug )); then
+			time eval $cmd
 		else
-			cmd="sudo -u $user sh -c '$cmd'"
+			eval $cmd
 		fi
 	fi
 
-	echo "Mapping PID $pid (user $user):"
-	if (( debug )); then
-		time eval $cmd
-	else
-		eval $cmd
-	fi
 	if [[ -e "$mapfile" ]]; then
 		chown root $mapfile
 		chmod 666 $mapfile

--- a/jmaps
+++ b/jmaps
@@ -74,16 +74,16 @@ for pid in $(pgrep -x java); do
 
 	user=$(ps ho user -p $pid)
 
-	container=$(cat /proc/$pid/cgroup | grep :/docker/ | awk -F/ '{ print $NF }' | head -n1)
-	if [[ $container != "" ]]; then
+	container=$(awk -F/ 'NR == 1 { print $NF }' /proc/$pid/cgroup)
+	if [[ "$container" != "" ]]; then
 		echo "Prorcess $pid is in container $container"
 
 		tmpfile=$(mktemp -u)
 
-		container_pid=$(cat /proc/$pid/status | grep ^NSpid | awk '{ print $NF }')
+		container_pid=$(awk -F: '$1 == "NSpid" { print $2 }' /proc/$pid/status | awk '{ print $2 }')
 		nsenter="sudo nsenter --target $pid --setuid $user --setgid $(sudo nsenter --target $pid --mount --pid id -g $user) --mount --pid"
 
-		java_home=$(sudo cat /proc/$pid/environ | xargs --null --max-args=1 | grep ^JAVA_HOME | awk -F= '{ print $2 }')
+		java_home=$(awk -F= 'BEGIN { RS = "\0" } $1 == "JAVA_HOME" { print $2 }' /proc/$pid/environ)
 		if [[ $java_home == "" ]]; then
 			java_home=$($nsenter jrunscript -e 'java.lang.System.out.println(java.lang.System.getProperty("java.home"));')
 		fi

--- a/jmaps
+++ b/jmaps
@@ -81,7 +81,10 @@ for pid in $(pgrep -x java); do
 		tmpfile=$(mktemp -u)
 
 		container_pid=$(awk -F: '$1 == "NSpid" { print $2 }' /proc/$pid/status | awk '{ print $2 }')
-		nsenter="nsenter --target $pid --setuid $user --setgid $(nsenter --target $pid --mount --pid id -g $user) --mount --pid"
+
+		container_gid=$(nsenter --target $pid --mount --pid id -g $user) || (echo "Failed to get container GID" && continue)
+
+		nsenter="nsenter --target $pid --setuid $user --setgid $container_gid --mount --pid"
 
 		java_home=$(awk -F= 'BEGIN { RS = "\0" } $1 == "JAVA_HOME" { print $2 }' /proc/$pid/environ)
 		if [[ $java_home == "" ]]; then


### PR DESCRIPTION
This is built on the following work:

* https://github.com/jvm-profiling-tools/perf-map-agent/issues/50
* http://batey.info/docker-jvm-flamegraphs.html
* https://github.com/chbatey/perf-map-agent/commit/60c50eb5519355b68bab8a3ddfdf1c9bf67d32f4

Sometimes `jrunscript` is not included in images. Should we try `JAVA_HOME` and fall back to `jrunscript` if it's missing?

Diff is better viewed with whitespace changes ignored. It's not very nice, though.

Here's a flamegraph from a test Logstash instance running in a container:

![image](https://user-images.githubusercontent.com/89186/40097557-a2d288e8-588b-11e8-9a9f-00d8bfeeaae7.png)

We used `flamegraph-perf` wrapper, which is essentially this:

```
/usr/bin/perf record -o perf.data "$@"

/usr/local/flamegraph/jmaps 1>&2

/usr/bin/perf script -i perf.data | /usr/local/flamegraph/stackcollapse-perf.pl --all | c++filt | fgrep -v cpuidle_enter_state | /usr/local/flamegraph/flamegraph.pl --colors=java --hash --title=$(hostname)
```

cc @chbatey, @alicegoldfuss, @jrudolph 