### PR TITLE
Check for _[k] before :: in the java colors oalette

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -379,10 +379,10 @@ sub color {
 			$type = "aqua";
 		} elsif ($name =~ m:^L?(java|org|com|io|sun)/:) {	# Java
 			$type = "green";
-		} elsif ($name =~ /::/) {	# C++
-			$type = "yellow";
 		} elsif ($name =~ m:_\[k\]$:) {	# kernel annotation
 			$type = "orange";
+		} elsif ($name =~ /::/) {	# C++
+			$type = "yellow";
 		} else {			# system
 			$type = "red";
 		}


### PR DESCRIPTION
I am using `_[k]` for internal methods in my flame graph generator with the java color palette, but because they contain `::`, `_[k]` doesn't have an effect, due to `::` being checked before `_[k]` in the java color palette