### PR TITLE
Handle SIGINT

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -571,8 +571,14 @@ my $ignored = 0;
 my $line;
 my $maxdelta = 1;
 
+# When FlameGraph is piped to another tool, still process the received lines
+# if Ctrl+C is pressed once. Interrupt FlameGraph when Ctrl+C is pressed twice.
+my $int_flag = 0;
+$SIG{INT} = sub { $int_flag += 1 };
+
 # reverse if needed
 foreach (<>) {
+	if ($int_flag == 2) { last;	}
 	chomp;
 	$line = $_;
 	if ($stackreverse) {


### PR DESCRIPTION
When FlameGraph is piped to another tool (e.g. [Austin](https://github.com/P403n1x87/austin)), pressing Ctrl+C causes the loss of all the input produced so far. The proposed change handles the SIGINT and interrups FlameGraph only on a second press of Ctrl+C. This allows any input received to be processed and still produce a partial graph.