### PR TITLE
support whitespace in paths in stackcollapse-perf.pl

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -250,7 +250,7 @@ while (defined($_ = <>)) {
 	#
 	# stack line
 	#
-	} elsif (/^\s*(\w+)\s*(.+) \((\S*)\)/) {
+	} elsif (/^\s*(\w+)\s*(.+) \(([\S ]*)\)/) {
 		# ignore filtered samples
 		next if not $pname;
 


### PR DESCRIPTION
Flame graphs of anything that uses Valve's Proton lose the Proton stack
frames because the regex does not handle the space in the directory name
"Proton 3.16".

Signed-off-by: Richard Yao <ryao@gentoo.org>