### PR TITLE
Improve naming convention for stackcollapse-xdebug.php

### DIFF
--- a/stackcollapse-xdebug.php
+++ b/stackcollapse-xdebug.php
@@ -154,6 +154,10 @@ if ($do_time) {
         } else {
             $func_name = $parts[5];
 
+            if (in_array($parts[5], ["require", "require_once", "include", "include_once"])) {
+                $func_name .= "(" . $parts[7] . ")";
+            }
+
             if (!empty($current_stack)) {
                 addCurrentStackToStacks($current_stack, $time - $prev_start_time, $stacks);
             }


### PR DESCRIPTION
Previously, this script would just show the function name. This change appends
the filename if one of a number of keywords are used. This allows you to
explicitly see which files are being included.

![](https://imgur.com/ECW3P2Q.png)