### PR TITLE
Optimize FlameGraphs by utilizing CSS and modern JS

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -720,10 +720,11 @@ my $inc = <<INC;
 <script type="text/ecmascript">
 <![CDATA[
 	"use strict";
-	var details, searchbtn, matchedtxt, svg, searching;
+	var details, searchbtn, unzoombtn, matchedtxt, svg, searching;
 	function init(evt) {
 		details = document.getElementById("details").firstChild;
 		searchbtn = document.getElementById("search");
+		unzoombtn = document.getElementById("unzoom");
 		matchedtxt = document.getElementById("matched");
 		svg = document.getElementsByTagName("svg")[0];
 		searching = 0;
@@ -877,7 +878,6 @@ my $inc = <<INC;
 		// XXX: Workaround for JavaScript float issues (fix me)
 		var fudge = 0.0001;
 
-		var unzoombtn = document.getElementById("unzoom");
 		unzoombtn.style.opacity = "1";
 
 		var el = document.getElementById("frames").children;
@@ -918,7 +918,6 @@ my $inc = <<INC;
 		}
 	}
 	function unzoom() {
-		var unzoombtn = document.getElementById("unzoom");
 		unzoombtn.style.opacity = "";
 
 		var el = document.getElementById("frames").children;

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -773,14 +773,14 @@ my $inc = <<INC;
 		find_parent(parent, name);
 	}
 	function orig_save(e, attr, val) {
-		if (e.attributes["_orig_"+attr] != undefined) return;
+		if (e.attributes["_orig_" + attr] != undefined) return;
 		if (e.attributes[attr] == undefined) return;
 		if (val == undefined) val = e.attributes[attr].value;
-		e.setAttribute("_orig_"+attr, val);
+		e.setAttribute("_orig_" + attr, val);
 	}
 	function orig_load(e, attr) {
 		if (e.attributes["_orig_"+attr] == undefined) return;
-		e.attributes[attr].value = e.attributes["_orig_"+attr].value;
+		e.attributes[attr].value = e.attributes["_orig_" + attr].value;
 		e.removeAttribute("_orig_"+attr);
 	}
 	function g_to_text(e) {
@@ -798,10 +798,10 @@ my $inc = <<INC;
 		var t = find_child(e, "text");
 		var w = parseFloat(r.attributes.width.value) -3;
 		var txt = find_child(e, "title").textContent.replace(/\\([^(]*\\)\$/,"");
-		t.attributes.x.value = parseFloat(r.attributes.x.value) +3;
+		t.attributes.x.value = parseFloat(r.attributes.x.value) + 3;
 
 		// Smaller than this size won't fit anything
-		if (w < 2*$fontsize*$fontwidth) {
+		if (w < 2 * $fontsize * $fontwidth) {
 			t.textContent = "";
 			return;
 		}
@@ -812,8 +812,8 @@ my $inc = <<INC;
 			return;
 
 		for (var x = txt.length - 2; x > 0; x--) {
-			if (t.getSubStringLength(0, x+2) <= w) {
-				t.textContent = txt.substring(0,x) + "..";
+			if (t.getSubStringLength(0, x + 2) <= w) {
+				t.textContent = txt.substring(0, x) + "..";
 				return;
 			}
 		}
@@ -827,7 +827,7 @@ my $inc = <<INC;
 			orig_load(e, "width");
 		}
 		if (e.childNodes == undefined) return;
-		for(var i = 0, c = e.childNodes; i < c.length; i++) {
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
 			zoom_reset(c[i]);
 		}
 	}
@@ -836,7 +836,8 @@ my $inc = <<INC;
 			if (e.attributes.x != undefined) {
 				orig_save(e, "x");
 				e.attributes.x.value = (parseFloat(e.attributes.x.value) - x - $xpad) * ratio + $xpad;
-				if(e.tagName == "text") e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
+				if (e.tagName == "text")
+					e.attributes.x.value = find_child(e.parentNode, "rect[x]").attributes.x.value + 3;
 			}
 			if (e.attributes.width != undefined) {
 				orig_save(e, "width");
@@ -845,8 +846,8 @@ my $inc = <<INC;
 		}
 
 		if (e.childNodes == undefined) return;
-		for(var i = 0, c = e.childNodes; i < c.length; i++) {
-			zoom_child(c[i], x-$xpad, ratio);
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
+			zoom_child(c[i], x - $xpad, ratio);
 		}
 	}
 	function zoom_parent(e) {
@@ -857,21 +858,21 @@ my $inc = <<INC;
 			}
 			if (e.attributes.width != undefined) {
 				orig_save(e, "width");
-				e.attributes.width.value = parseInt(svg.width.baseVal.value) - ($xpad*2);
+				e.attributes.width.value = parseInt(svg.width.baseVal.value) - ($xpad * 2);
 			}
 		}
 		if (e.childNodes == undefined) return;
-		for(var i = 0, c = e.childNodes; i < c.length; i++) {
+		for (var i = 0, c = e.childNodes; i < c.length; i++) {
 			zoom_parent(c[i]);
 		}
 	}
 	function zoom(node) {
 		var attr = find_child(node, "rect").attributes;
-		var width = parseFloat(attr["width"].value);
-		var xmin = parseFloat(attr["x"].value);
+		var width = parseFloat(attr.width.value);
+		var xmin = parseFloat(attr.x.value);
 		var xmax = parseFloat(xmin + width);
-		var ymin = parseFloat(attr["y"].value);
-		var ratio = (svg.width.baseVal.value - 2*$xpad) / width;
+		var ymin = parseFloat(attr.y.value);
+		var ratio = (svg.width.baseVal.value - 2 * $xpad) / width;
 
 		// XXX: Workaround for JavaScript float issues (fix me)
 		var fudge = 0.0001;
@@ -880,17 +881,17 @@ my $inc = <<INC;
 		unzoombtn.style.opacity = "1";
 
 		var el = document.getElementById("frames").children;
-		for(var i = 0; i < el.length; i++) {
+		for (var i = 0; i < el.length; i++) {
 			var e = el[i];
 			var a = find_child(e, "rect").attributes;
-			var ex = parseFloat(a["x"].value);
-			var ew = parseFloat(a["width"].value);
+			var ex = parseFloat(a.x.value);
+			var ew = parseFloat(a.width.value);
 			var upstack;
 			// Is it an ancestor
 			if ($inverted == 0) {
-				upstack = parseFloat(a["y"].value) > ymin;
+				upstack = parseFloat(a.y.value) > ymin;
 			} else {
-				upstack = parseFloat(a["y"].value) < ymin;
+				upstack = parseFloat(a.y.value) < ymin;
 			}
 			if (upstack) {
 				// Direct ancestor

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -719,7 +719,8 @@ my $inc = <<INC;
 </style>
 <script type="text/ecmascript">
 <![CDATA[
-	var details, searchbtn, matchedtxt, svg;
+	"use strict";
+	var details, searchbtn, matchedtxt, svg, searching;
 	function init(evt) {
 		details = document.getElementById("details").firstChild;
 		searchbtn = document.getElementById("search");
@@ -762,7 +763,7 @@ my $inc = <<INC;
 	// functions
 	function find_child(parent, name, attr) {
 		var children = parent.childNodes;
-		for (var i=0; i<children.length;i++) {
+		for (var i = 0; i < children.length; i++) {
 			if (children[i].tagName == name)
 				return (attr != undefined) ? children[i].attributes[attr].value : children[i];
 		}
@@ -813,7 +814,7 @@ my $inc = <<INC;
 		if (/^ *\$/.test(txt) || t.getSubStringLength(0, txt.length) < w)
 			return;
 
-		for (var x=txt.length-2; x>0; x--) {
+		for (var x = txt.length - 2; x > 0; x--) {
 			if (t.getSubStringLength(0, x+2) <= w) {
 				t.textContent = txt.substring(0,x) + "..";
 				return;
@@ -829,7 +830,7 @@ my $inc = <<INC;
 			orig_load(e, "width");
 		}
 		if (e.childNodes == undefined) return;
-		for(var i=0, c=e.childNodes; i<c.length; i++) {
+		for(var i = 0, c = e.childNodes; i < c.length; i++) {
 			zoom_reset(c[i]);
 		}
 	}
@@ -847,7 +848,7 @@ my $inc = <<INC;
 		}
 
 		if (e.childNodes == undefined) return;
-		for(var i=0, c=e.childNodes; i<c.length; i++) {
+		for(var i = 0, c = e.childNodes; i < c.length; i++) {
 			zoom_child(c[i], x-$xpad, ratio);
 		}
 	}
@@ -863,7 +864,7 @@ my $inc = <<INC;
 			}
 		}
 		if (e.childNodes == undefined) return;
-		for(var i=0, c=e.childNodes; i<c.length; i++) {
+		for(var i = 0, c = e.childNodes; i < c.length; i++) {
 			zoom_parent(c[i]);
 		}
 	}
@@ -882,16 +883,17 @@ my $inc = <<INC;
 		unzoombtn.style.opacity = "1";
 
 		var el = document.getElementsByTagName("g");
-		for(var i=0;i<el.length;i++){
+		for(var i = 0; i < el.length; i++) {
 			var e = el[i];
 			var a = find_child(e, "rect").attributes;
 			var ex = parseFloat(a["x"].value);
 			var ew = parseFloat(a["width"].value);
+			var upstack;
 			// Is it an ancestor
 			if ($inverted == 0) {
-				var upstack = parseFloat(a["y"].value) > ymin;
+				upstack = parseFloat(a["y"].value) > ymin;
 			} else {
-				var upstack = parseFloat(a["y"].value) < ymin;
+				upstack = parseFloat(a["y"].value) < ymin;
 			}
 			if (upstack) {
 				// Direct ancestor
@@ -922,7 +924,7 @@ my $inc = <<INC;
 		unzoombtn.style.opacity = "";
 
 		var el = document.getElementsByTagName("g");
-		for(i=0;i<el.length;i++) {
+		for(var i = 0; i < el.length; i++) {
 			el[i].style.display = "";
 			el[i].style.opacity = "";
 			zoom_reset(el[i]);
@@ -933,7 +935,7 @@ my $inc = <<INC;
 	// search
 	function reset_search() {
 		var el = document.getElementsByTagName("rect");
-		for (var i=0; i < el.length; i++) {
+		for (var i = 0; i < el.length; i++) {
 			orig_load(el[i], "fill")
 		}
 	}
@@ -1032,11 +1034,8 @@ my $inc = <<INC;
 		}
 		// display matched percent
 		matchedtxt.style.opacity = "1";
-		pct = 100 * count / maxwidth;
-		if (pct == 100)
-			pct = "100"
-		else
-			pct = pct.toFixed(1)
+		var pct = 100 * count / maxwidth;
+		if (pct != 100) pct = pct.toFixed(1)
 		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
 	}
 ]]>

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -308,9 +308,9 @@ SVG
 	sub stringTTF {
 		my ($self, $color, $font, $size, $angle, $x, $y, $str, $loc, $extra) = @_;
 		$x = sprintf "%0.2f", $x;
-		$loc = defined $loc ? $loc : "left";
+		$loc =  defined $loc ? "text-anchor=\"$loc\"" : "";
 		$extra = defined $extra ? $extra : "";
-		$self->{svg} .= qq/<text text-anchor="$loc" x="$x" y="$y" font-size="$size" font-family="$font" fill="$color" $extra >$str<\/text>\n/;
+		$self->{svg} .= qq/<text $loc x="$x" y="$y" font-size="$size" font-family="$font" fill="$color" $extra >$str<\/text>\n/;
 	}
 
 	sub svg {
@@ -1038,12 +1038,12 @@ $im->stringTTF($black, $fonttype, $fontsize + 5, 0.0, int($imagewidth / 2), $fon
 if ($subtitletext ne "") {
 	$im->stringTTF($vdgrey, $fonttype, $fontsize, 0.0, int($imagewidth / 2), $fontsize * 4, $subtitletext, "middle");
 }
-$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $imageheight - ($ypad2 / 2), " ", "", 'id="details"');
+$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $imageheight - ($ypad2 / 2), " ", undef, 'id="details"');
 $im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $fontsize * 2,
-    "Reset Zoom", "", 'id="unzoom" onclick="unzoom()" style="opacity:0.0;cursor:pointer"');
+    "Reset Zoom", undef, 'id="unzoom" onclick="unzoom()" style="opacity:0.0;cursor:pointer"');
 $im->stringTTF($black, $fonttype, $fontsize, 0.0, $imagewidth - $xpad - 100,
-    $fontsize * 2, "Search", "", 'id="search" onmouseover="searchover()" onmouseout="searchout()" onclick="search_prompt()" style="opacity:0.1;cursor:pointer"');
-$im->stringTTF($black, $fonttype, $fontsize, 0.0, $imagewidth - $xpad - 100, $imageheight - ($ypad2 / 2), " ", "", 'id="matched"');
+    $fontsize * 2, "Search", undef, 'id="search" onmouseover="searchover()" onmouseout="searchout()" onclick="search_prompt()" style="opacity:0.1;cursor:pointer"');
+$im->stringTTF($black, $fonttype, $fontsize, 0.0, $imagewidth - $xpad - 100, $imageheight - ($ypad2 / 2), " ", undef, 'id="matched"');
 
 if ($palette) {
 	read_palette();
@@ -1126,7 +1126,7 @@ while (my ($id, $node) = each %Node) {
 		$text =~ s/</&lt;/g;
 		$text =~ s/>/&gt;/g;
 	}
-	$im->stringTTF($black, $fonttype, $fontsize, 0.0, $x1 + 3, 3 + ($y1 + $y2) / 2, $text, "");
+	$im->stringTTF($black, $fonttype, $fontsize, 0.0, $x1 + 3, 3 + ($y1 + $y2) / 2, $text);
 
 	$im->group_end($nameattr);
 }

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -718,14 +718,26 @@ my $inc = <<INC;
 		searching = 0;
 	}
 
+	window.addEventListener("click", function(e) {
+		var target = find_parent(e.target, "g", "func_g");
+		if (target) {
+			if (target.style['opacity'] == 0.5) unzoom();
+			zoom(target);
+		}
+	}, false)
+
 	// mouse-over for info
-	function s(node) {		// show
-		info = g_to_text(node);
-		details.nodeValue = "$nametype " + info;
-	}
-	function c() {			// clear
-		details.nodeValue = ' ';
-	}
+	// show
+	window.addEventListener("mouseover", function(e) {
+		var target = find_parent(e.target, "g", "func_g");
+		if (target) details.nodeValue = "$nametype " + g_to_text(target);
+	}, false)
+
+	// clear
+	window.addEventListener("mouseout", function(e) {
+		var target = find_parent(e.target, "g", "func_g");
+		if (target) details.nodeValue = ' ';
+	}, false)
 
 	// ctrl-F for search
 	window.addEventListener("keydown",function (e) {
@@ -733,7 +745,7 @@ my $inc = <<INC;
 			e.preventDefault();
 			search_prompt();
 		}
-	})
+	}, false)
 
 	// functions
 	function find_child(parent, name, attr) {
@@ -743,6 +755,12 @@ my $inc = <<INC;
 				return (attr != undefined) ? children[i].attributes[attr].value : children[i];
 		}
 		return;
+	}
+	function find_parent(node, name, className) {
+		var parent = node.parentElement;
+		if (!parent) return;
+		if (parent.tagName == name && (className == undefined || (parent.classList && parent.classList.contains(className)))) return parent;
+		find_parent(parent, name);
 	}
 	function orig_save(e, attr, val) {
 		if (e.attributes["_orig_"+attr] != undefined) return;
@@ -868,7 +886,6 @@ my $inc = <<INC;
 				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
 					e.style["opacity"] = "0.5";
 					zoom_parent(e);
-					e.onclick = function(e){unzoom(); zoom(this);};
 					update_text(e);
 				}
 				// not in current path
@@ -883,7 +900,6 @@ my $inc = <<INC;
 				}
 				else {
 					zoom_child(e, xmin, ratio);
-					e.onclick = function(e){zoom(this);};
 					update_text(e);
 				}
 			}
@@ -1096,9 +1112,6 @@ while (my ($id, $node) = each %Node) {
 
 	my $nameattr = { %{ $nameattr{$func}||{} } }; # shallow clone
 	$nameattr->{class}       ||= "func_g";
-	$nameattr->{onmouseover} ||= "s(this)";
-	$nameattr->{onmouseout}  ||= "c()";
-	$nameattr->{onclick}     ||= "zoom(this)";
 	$nameattr->{title}       ||= $info;
 	$im->group_start($nameattr);
 

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -306,7 +306,7 @@ SVG
 	}
 
 	sub stringTTF {
-		my ($self, $color, $font, $size, $angle, $x, $y, $str, $loc, $extra) = @_;
+		my ($self, $color, $font, $size, $x, $y, $str, $loc, $extra) = @_;
 		$x = sprintf "%0.2f", $x;
 		$loc =  defined $loc ? "text-anchor=\"$loc\"" : "";
 		$extra = defined $extra ? $extra : "";
@@ -664,7 +664,7 @@ unless ($time) {
 	my $imageheight = $fontsize * 5;
 	$im->header($imagewidth, $imageheight);
 	$im->stringTTF($im->colorAllocate(0, 0, 0), $fonttype, $fontsize + 2,
-	    0.0, int($imagewidth / 2), $fontsize * 2,
+	    int($imagewidth / 2), $fontsize * 2,
 	    "ERROR: No valid input provided to flamegraph.pl.", "middle");
 	print $im->svg;
 	exit 2;
@@ -1050,16 +1050,16 @@ my ($white, $black, $vvdgrey, $vdgrey, $dgrey) = (
 	$im->colorAllocate(160, 160, 160),
 	$im->colorAllocate(200, 200, 200),
     );
-$im->stringTTF($black, $fonttype, $fontsize + 5, 0.0, int($imagewidth / 2), $fontsize * 2, $titletext, "middle");
+$im->stringTTF($black, $fonttype, $fontsize + 5, int($imagewidth / 2), $fontsize * 2, $titletext, "middle");
 if ($subtitletext ne "") {
-	$im->stringTTF($vdgrey, $fonttype, $fontsize, 0.0, int($imagewidth / 2), $fontsize * 4, $subtitletext, "middle");
+	$im->stringTTF($vdgrey, $fonttype, $fontsize, int($imagewidth / 2), $fontsize * 4, $subtitletext, "middle");
 }
-$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $imageheight - ($ypad2 / 2), " ", undef, 'id="details"');
-$im->stringTTF($black, $fonttype, $fontsize, 0.0, $xpad, $fontsize * 2,
+$im->stringTTF($black, $fonttype, $fontsize, $xpad, $imageheight - ($ypad2 / 2), " ", undef, 'id="details"');
+$im->stringTTF($black, $fonttype, $fontsize, $xpad, $fontsize * 2,
     "Reset Zoom", undef, 'id="unzoom" onclick="unzoom()" style="opacity:0.0;cursor:pointer"');
-$im->stringTTF($black, $fonttype, $fontsize, 0.0, $imagewidth - $xpad - 100,
+$im->stringTTF($black, $fonttype, $fontsize, $imagewidth - $xpad - 100,
     $fontsize * 2, "Search", undef, 'id="search" onmouseover="searchover()" onmouseout="searchout()" onclick="search_prompt()" style="opacity:0.1;cursor:pointer"');
-$im->stringTTF($black, $fonttype, $fontsize, 0.0, $imagewidth - $xpad - 100, $imageheight - ($ypad2 / 2), " ", undef, 'id="matched"');
+$im->stringTTF($black, $fonttype, $fontsize, $imagewidth - $xpad - 100, $imageheight - ($ypad2 / 2), " ", undef, 'id="matched"');
 
 if ($palette) {
 	read_palette();
@@ -1139,7 +1139,7 @@ while (my ($id, $node) = each %Node) {
 		$text =~ s/</&lt;/g;
 		$text =~ s/>/&gt;/g;
 	}
-	$im->stringTTF($black, $fonttype, $fontsize, 0.0, $x1 + 3, 3 + ($y1 + $y2) / 2, $text);
+	$im->stringTTF($black, $fonttype, $fontsize, $x1 + 3, 3 + ($y1 + $y2) / 2, $text);
 
 	$im->group_end($nameattr);
 }

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -927,7 +927,8 @@ my $inc = <<INC;
 		unzoombtn.classList.add("hide");
 		var el = document.getElementById("frames").children;
 		for(var i = 0; i < el.length; i++) {
-			el[i].classList.remove("parent", "hide");
+			el[i].classList.remove("parent");
+			el[i].classList.remove("hide");
 			zoom_reset(el[i]);
 			update_text(el[i]);
 		}


### PR DESCRIPTION
Hey @brendangregg, thanks for FlameGraph, it helped me and my colleagues debug a lot of issues and it is one of the most valuable visualization tools in my debugging bag. We really, really appreciate it! One of many examples: We use Devel::NYTProf[1] for debugging Perl applications and always generated a second FlameGraph to zoom in frames since NYTProf uses the nameattr option to map calls to source code references, which causes a click on a frame to follow a link. So to mitigate the problem, I poked around a bit to see if I could come up with a reasonable implementation. Whilst analyzing the code, I found a couple of low hanging fruits for optimizing the generated SVG by leveraging some of CSS features and a bit of restructuring to simplify some of the JavaScript and Perl code.

A brief overview:

- Instead of using the event attributes, the events are registered in Javascript utilizing event delegation, which generally is about 30% faster. So basically all <g> elements lose the onclick/onmouseover/onmouseout attributes which also reduces the generated SVG size (see f859e9f).
- Wrap all frames into a group with the id `#frames`, eliminating the need to attach the class name `func_g` to each group element. This reduces the SVG further, especially on files with a lot of frames (see 3e17d0a).
- Utilized CSS for the font settings, reducing the options passed to stringTTS and also reding the size of the generated SVG, since the settings are defined once and not duplicated on the frames. (see 9fd4fa3).
- Moved CSS manipulation out of JavaScript and use classes for styling. Separating CSS/JS allows us to change the style in one place. This could also be used to implement loading in custom CSS. (see 
a2938e8).
- Collapsed the `<a>` element into the `<g>` element, since they are both defined as containers in the SVG specs, eliminating the need of workarounds for the data structures, for example #62 (see d4d085c).
- When using the nameattr option, it is now possible to zoom in using ctrl+click, I didn't implement any indicator, since I didn't want to make any presumptions on how it should be implemented/displayed, so I am open for any suggestion (see also d4d085c).
- Based on those changes I also updated the JavaScript code a bit, I tried to stay IE10+ compatible for that (see bf02650).

The reduced size of the SVG depends on the frames, for the `example-perf-stacks.txt.gz` dataset was about 30%, the more frames the higher the reduction. I'd be very interested to see the savings on a larger dataset.

I realize those are a lot of changes, and I tried my best to document my reasoning in the commit messages along with references, so any feedback is welcomed.

There are still a couple of areas that could be improved for performance, especially on the data structure and I would be happy to discuss/implement them.

[1] https://metacpan.org/pod/Devel::NYTProf