### PR TITLE
Implement state for zoom and search

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -761,8 +761,10 @@ my $inc = <<INC;
 		var params = get_params();
 		if (params.x && params.y)
 			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
-		if (params.s)
-			search(params.s);
+                if (params.s) {
+			currentSearchTerm = params.s;
+			search();
+                }
 	}
 
 	// event listeners

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -1091,7 +1091,7 @@ my $inc = <<INC;
 		if (!searching)
 			return;
 		var params = get_params();
-		params.s = encodeURIComponent(term);
+		params.s = term;
 		history.replaceState(null, null, parse_params(params));
 
 		searchbtn.classList.add("show");

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -848,7 +848,6 @@ my $inc = <<INC;
 	function find_child(node, selector) {
 		var children = node.querySelectorAll(selector);
 		if (children.length) return children[0];
-		return;
 	}
 	function find_group(node) {
 		var parent = node.parentElement;

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -757,8 +757,8 @@ my $inc = <<INC;
 		searching = 0;
 		currentSearchTerm = null;
 		var params = get_params();
-		if (params.y && params.x)
-			zoom(find_group(document.querySelector('[y="' + params.y + '"][x="' + params.x + '"]')));
+		if (params.x && params.y)
+			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
 		if (params.s)
 			search(decodeURIComponent(params.s));
 	}
@@ -775,10 +775,10 @@ my $inc = <<INC;
 			var el = target.querySelector("rect");
 			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
 				var params = get_params()
-				params.y = el.attributes.y.value;
 				params.x = el.attributes._orig_x.value ?
 						el.attributes._orig_x.value :
 						el.attributes.x.value;
+				params.y = el.attributes.y.value;
 				history.replaceState(null, null, parse_params(params));
 			}
 		}

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -761,10 +761,7 @@ my $inc = <<INC;
 		var params = get_params();
 		if (params.x && params.y)
 			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
-                if (params.s) {
-			currentSearchTerm = params.s;
-			search();
-                }
+                if (params.s) search(params.s);
 	}
 
 	// event listeners
@@ -1042,10 +1039,7 @@ my $inc = <<INC;
 			    "allowed, eg: ^ext4_)"
 			    + (ignorecase ? ", ignoring case" : "")
 			    + "\\nPress Ctrl-i to toggle case sensitivity", "");
-			if (term != null) {
-				currentSearchTerm = term;
-				search();
-			}
+			if (term != null) search(term);
 		} else {
 			reset_search();
 			searching = 0;
@@ -1057,10 +1051,9 @@ my $inc = <<INC;
 		}
 	}
 	function search(term) {
-		if (currentSearchTerm === null) return;
-		var term = currentSearchTerm;
+		if (term) currentSearchTerm = term;
 
-		var re = new RegExp(term, ignorecase ? 'i' : '');
+		var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
 		var el = document.getElementById("frames").children;
 		var matches = new Object();
 		var maxwidth = 0;
@@ -1097,7 +1090,7 @@ my $inc = <<INC;
 		if (!searching)
 			return;
 		var params = get_params();
-		params.s = term;
+		params.s = currentSearchTerm;
 		history.replaceState(null, null, parse_params(params));
 
 		searchbtn.classList.add("show");

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -756,13 +756,16 @@ my $inc = <<INC;
 		svg = document.getElementsByTagName("svg")[0];
 		searching = 0;
 		currentSearchTerm = null;
+
+		// use GET parameters to restore a flamegraphs state.
 		var params = get_params();
 		if (params.x && params.y)
 			zoom(find_group(document.querySelector('[x="' + params.x + '"][y="' + params.y + '"]')));
 		if (params.s)
-			search(decodeURIComponent(params.s));
+			search(params.s);
 	}
 
+	// event listeners
 	window.addEventListener("click", function(e) {
 		var target = find_group(e.target);
 		if (target) {
@@ -772,6 +775,8 @@ my $inc = <<INC;
 			}
 			if (target.classList.contains("parent")) unzoom();
 			zoom(target);
+
+			// set parameters for zoom state
 			var el = target.querySelector("rect");
 			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
 				var params = get_params()
@@ -781,11 +786,13 @@ my $inc = <<INC;
 			}
 		}
 		else if (e.target.id == "unzoom") {
+			unzoom();
+
+			// remove zoom state
 			var params = get_params();
 			if (params.x) delete params.x;
 			if (params.y) delete params.y;
 			history.replaceState(null, null, parse_params(params));
-			unzoom();
 		}
 		else if (e.target.id == "search") search_prompt();
 		else if (e.target.id == "ignorecase") toggle_ignorecase();
@@ -827,7 +834,7 @@ my $inc = <<INC;
 		for (var i = 0; i < paramsarr.length; ++i) {
 			var tmp = paramsarr[i].split("=");
 			if (!tmp[0] || !tmp[1]) continue;
-			params[tmp[0]]  = tmp[1];
+			params[tmp[0]]  = decodeURIComponent(tmp[1]);
 		}
 		return params;
 	}

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -840,6 +840,8 @@ my $inc = <<INC;
 		}
 		if (uri.slice(-1) == "&")
 			uri = uri.substring(0, uri.length - 1);
+		if (uri == '?')
+			uri = window.location.href.split('?')[0];
 		return uri;
 	}
 	function find_child(node, selector) {

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -756,12 +756,7 @@ my $inc = <<INC;
 		svg = document.getElementsByTagName("svg")[0];
 		searching = 0;
 		currentSearchTerm = null;
-		var params = {};
-		var paramsarr = window.location.search.substr(1).split('&');
-		for (var i = 0; i < paramsarr.length; ++i) {
-			var tmp = paramsarr[i].split("=");
-			params[tmp[0]]  = tmp[1];
-		}
+		var params = get_params();
 		if (params.y && params.x)
 			zoom(find_group(document.querySelector('[y="' + params.y + '"][x="' + params.x + '"]')));
 	}
@@ -777,17 +772,19 @@ my $inc = <<INC;
 			zoom(target);
 			var el = target.querySelector("rect");
 			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
-				var params = {
-					"y": el.attributes.y.value,
-					"x": el.attributes._orig_x.value ?
+				var params = get_params()
+				params.y = el.attributes.y.value;
+				params.x = el.attributes._orig_x.value ?
 						el.attributes._orig_x.value :
-						el.attributes.x.value
-				};
-				history.replaceState(null, null, "?y=" + params.y + "&x=" + params.x);
+						el.attributes.x.value;
+				history.replaceState(null, null, parse_params(params));
 			}
 		}
 		else if (e.target.id == "unzoom") {
-			history.replaceState(null, null, "?");
+			var params = get_params();
+			if (params.x) delete params.x;
+			if (params.y) delete params.y;
+			history.replaceState(null, null, parse_params(params));
 			unzoom();
 		}
 		else if (e.target.id == "search") search_prompt();
@@ -824,6 +821,25 @@ my $inc = <<INC;
 	}, false)
 
 	// functions
+	function get_params() {
+		var params = {};
+		var paramsarr = window.location.search.substr(1).split('&');
+		for (var i = 0; i < paramsarr.length; ++i) {
+			var tmp = paramsarr[i].split("=");
+			if (!tmp[0] || !tmp[1]) continue;
+			params[tmp[0]]  = tmp[1];
+		}
+		return params;
+	}
+	function parse_params(params) {
+		var uri = "?";
+		for (var key in params) {
+			uri += key + '=' + encodeURIComponent(params[key]) + '&';
+		}
+		if (uri.slice(-1) == "&")
+			uri = uri.substring(0, uri.length - 1);
+		return uri;
+	}
 	function find_child(node, selector) {
 		var children = node.querySelectorAll(selector);
 		if (children.length) return children[0];

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -775,9 +775,7 @@ my $inc = <<INC;
 			var el = target.querySelector("rect");
 			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
 				var params = get_params()
-				params.x = el.attributes._orig_x.value ?
-						el.attributes._orig_x.value :
-						el.attributes.x.value;
+				params.x = el.attributes._orig_x.value;
 				params.y = el.attributes.y.value;
 				history.replaceState(null, null, parse_params(params));
 			}

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -756,6 +756,14 @@ my $inc = <<INC;
 		svg = document.getElementsByTagName("svg")[0];
 		searching = 0;
 		currentSearchTerm = null;
+		var params = {};
+		var paramsarr = window.location.search.substr(1).split('&');
+		for (var i = 0; i < paramsarr.length; ++i) {
+			var tmp = paramsarr[i].split("=");
+			params[tmp[0]]  = tmp[1];
+		}
+		if (params.y && params.x)
+			zoom(find_group(document.querySelector('[y="' + params.y + '"][x="' + params.x + '"]')));
 	}
 
 	window.addEventListener("click", function(e) {
@@ -767,8 +775,21 @@ my $inc = <<INC;
 			}
 			if (target.classList.contains("parent")) unzoom();
 			zoom(target);
+			var el = target.querySelector("rect");
+			if (el && el.attributes && el.attributes.y && el.attributes._orig_x) {
+				var params = {
+					"y": el.attributes.y.value,
+					"x": el.attributes._orig_x.value ?
+						el.attributes._orig_x.value :
+						el.attributes.x.value
+				};
+				history.replaceState(null, null, "?y=" + params.y + "&x=" + params.x);
+			}
 		}
-		else if (e.target.id == "unzoom") unzoom();
+		else if (e.target.id == "unzoom") {
+			history.replaceState(null, null, "?");
+			unzoom();
+		}
 		else if (e.target.id == "search") search_prompt();
 		else if (e.target.id == "ignorecase") toggle_ignorecase();
 	}, false)

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -759,6 +759,8 @@ my $inc = <<INC;
 		var params = get_params();
 		if (params.y && params.x)
 			zoom(find_group(document.querySelector('[y="' + params.y + '"][x="' + params.x + '"]')));
+		if (params.s)
+			search(decodeURIComponent(params.s));
 	}
 
 	window.addEventListener("click", function(e) {
@@ -1024,6 +1026,9 @@ my $inc = <<INC;
 		for (var i = 0; i < el.length; i++) {
 			orig_load(el[i], "fill")
 		}
+		var params = get_params();
+		delete params.s;
+		history.replaceState(null, null, parse_params(params));
 	}
 	function search_prompt() {
 		if (!searching) {
@@ -1085,6 +1090,9 @@ my $inc = <<INC;
 		}
 		if (!searching)
 			return;
+		var params = get_params();
+		params.s = encodeURIComponent(term);
+		history.replaceState(null, null, parse_params(params));
 
 		searchbtn.classList.add("show");
 		searchbtn.firstChild.nodeValue = "Reset Search";

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -814,16 +814,13 @@ my $inc = <<INC;
 	}, false)
 
 	// ctrl-F for search
+	// ctrl-I to toggle case-sensitive search
 	window.addEventListener("keydown",function (e) {
 		if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
 			e.preventDefault();
 			search_prompt();
 		}
-	}, false)
-
-	// ctrl-I to toggle case-sensitive search
-	window.addEventListener("keydown",function (e) {
-		if (e.ctrlKey && e.keyCode === 73) {
+		else if (e.ctrlKey && e.keyCode === 73) {
 			e.preventDefault();
 			toggle_ignorecase();
 		}

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -774,6 +774,10 @@ my $inc = <<INC;
 			}
 			if (target.classList.contains("parent")) unzoom();
 			zoom(target);
+			if (!document.querySelector('.parent')) {
+				clearzoom();
+				return;
+			}
 
 			// set parameters for zoom state
 			var el = target.querySelector("rect");
@@ -784,15 +788,7 @@ my $inc = <<INC;
 				history.replaceState(null, null, parse_params(params));
 			}
 		}
-		else if (e.target.id == "unzoom") {
-			unzoom();
-
-			// remove zoom state
-			var params = get_params();
-			if (params.x) delete params.x;
-			if (params.y) delete params.y;
-			history.replaceState(null, null, parse_params(params));
-		}
+		else if (e.target.id == "unzoom") clearzoom();
 		else if (e.target.id == "search") search_prompt();
 		else if (e.target.id == "ignorecase") toggle_ignorecase();
 	}, false)
@@ -1010,6 +1006,15 @@ my $inc = <<INC;
 			update_text(el[i]);
 		}
 		search();
+	}
+	function clearzoom() {
+		unzoom();
+
+		// remove zoom state
+		var params = get_params();
+		if (params.x) delete params.x;
+		if (params.y) delete params.y;
+		history.replaceState(null, null, parse_params(params));
 	}
 
 	// search


### PR DESCRIPTION
Hey @brendangregg,

looking through old PRs I found  #134 very interesting. I have implemented a history safe (meaning the browsers back and forward functions won't interfere) solution that "safes" the zoom and/or search state.

It basically uses CSS attribute selectors[1] to match a frame (`[x=100][y=200]`) and uses GET parameters using the `history` API[2] to "store" the current zoom/search state.

Cheers,

Mike

[1] https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors
[2] https://developer.mozilla.org/en-US/docs/Web/API/History_API