### PR TITLE
Mark EPoll.wait as WAITING

### DIFF
--- a/stackcollapse-jstack.pl
+++ b/stackcollapse-jstack.pl
@@ -154,6 +154,8 @@ clear:
 
 		# fix state for epollWait
 		$state = "WAITING" if $func =~ /epollWait/;
+		$state = "WAITING" if $func =~ /EPoll\.wait/;
+
 
 		# fix state for various networking functions
 		$state = "NETWORK" if $func =~ /socketAccept$/;


### PR DESCRIPTION
Depending on `Selector` implementation, the IO blocking method can be
`epollWait` or `EPoll.wait`.  Mark threads to be in waiting state if
they are in `EPoll.wait`.