### PR TITLE
Ignore random number in Lambda function names

### DIFF
--- a/stackcollapse-jstack.pl
+++ b/stackcollapse-jstack.pl
@@ -145,6 +145,9 @@ clear:
 		$state = $1 if $state eq "?";
 	} elsif (/^\s*at ([^\(]*)/) {
 		my $func = $1;
+		# Strip out trailing number that is included in lambda functions
+		# This is not generated consistently by the JVM, so don't rely on it
+		$func =~ s/\$\$Lambda\$[0-9]+\/.*$/\$\$Lambda\$/;
 		if ($shorten_pkgs) {
 			my ($pkgs, $clsFunc) = ( $func =~ m/(.*\.)([^.]+\.[^.]+)$/ );
 			$pkgs =~ s/(\w)\w*/$1/g;


### PR DESCRIPTION
This change excludes the part of the function name in lambdas that are not
guaranteed by the JVM to be consistent. This makes the collapsed
stacktrace more meaningful when collected across a cluster of jvms running
the same code.

For example
  com.company.project.pkg.Class\$InnerClass\$\$Lambda\$469/0x00007fb8a5acdd00.call
will be
  com.company.project.pkg.Class\$InnerClass\$\$Lambda\$