### PR TITLE
Find interpreters using env for portability

### DIFF
--- a/aix-perf.pl
+++ b/aix-perf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use Getopt::Std;
 

--- a/dev/gatherhc-kern.d
+++ b/dev/gatherhc-kern.d
@@ -1,4 +1,4 @@
-#!/usr/sbin/dtrace -s
+#!/usr/bin/env -S dtrace -s
 
 #pragma D option stackframes=100
 #pragma D option defaultargs

--- a/dev/gatherthc-kern.d
+++ b/dev/gatherthc-kern.d
@@ -1,4 +1,4 @@
-#!/usr/sbin/dtrace -s
+#!/usr/bin/env -S dtrace -s
 
 #pragma D option stackframes=100
 #pragma D option defaultargs

--- a/dev/hcstackcollapse.pl
+++ b/dev/hcstackcollapse.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # hcstackcollapse.pl	collapse hot/cold multiline stacks into single lines.
 #

--- a/dev/hotcoldgraph.pl
+++ b/dev/hotcoldgraph.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # hotcoldgraph.pl	flame/cold stack grapher.
 #

--- a/dev/thcstackcollapse.pl
+++ b/dev/thcstackcollapse.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # thcstackcollapse.pl	collapse thread hot/cold multiline stacks into
 #			single lines.

--- a/difffolded.pl
+++ b/difffolded.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # difffolded.pl 	diff two folded stack files. Use this for generating
 #			flame graph differentials.

--- a/files.pl
+++ b/files.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # files.pl	Print file sizes in folded format, for a flame graph.
 #

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # flamegraph.pl		flame stack grapher.
 #

--- a/jmaps
+++ b/jmaps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 #
 # jmaps - creates java /tmp/perf-PID.map symbol maps for all java processes.
 #

--- a/pkgsplit-perf.pl
+++ b/pkgsplit-perf.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # pkgsplit-perf.pl	Split IP samples on package names "/", eg, Java.
 #

--- a/stackcollapse-aix.pl
+++ b/stackcollapse-aix.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -ws
+#!/usr/bin/env -S perl -ws
 #
 # stackcollapse-aix  Collapse AIX /usr/bin/procstack backtraces
 #

--- a/stackcollapse-gdb.pl
+++ b/stackcollapse-gdb.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -ws
+#!/usr/bin/env -S perl -ws
 #
 # stackcollapse-gdb  Collapse GDB backtraces
 #

--- a/stackcollapse-instruments.pl
+++ b/stackcollapse-instruments.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # stackcollapse-instruments.pl
 #

--- a/stackcollapse-jstack.pl
+++ b/stackcollapse-jstack.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env -S perl -w
 #
 # stackcollapse-jstack.pl	collapse jstack samples into single lines.
 #

--- a/stackcollapse-recursive.pl
+++ b/stackcollapse-recursive.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -ws
+#!/usr/bin/env -S perl -ws
 #
 # stackcollapse-recursive  Collapse direct recursive backtraces
 #


### PR DESCRIPTION
Let `/usr/bin/env` find the right interpreter for the scripts.
It makes the scripts more portable, allowing to use interpreters located elsewhere.