### PR TITLE
Get the process' running GID in addition to UID

### DIFF
--- a/jmaps
+++ b/jmaps
@@ -76,12 +76,13 @@ for pid in $(pgrep -x java); do
 	(( debug )) && echo $cmd
 
 	user=$(ps ho user -p $pid)
+	group=$(ps ho group -p $pid)
 	if [[ "$user" != root ]]; then
 		if [[ "$user" == [0-9]* ]]; then
-			# UID only, run sudo with #UID:
-			cmd="sudo -u '#'$user sh -c '$cmd'"
+			# UID only, likely GID too, run sudo with #UID:
+			cmd="sudo -u '#'$user -g '#'$group sh -c '$cmd'"
 		else
-			cmd="sudo -u $user sh -c '$cmd'"
+			cmd="sudo -u $user -g $group sh -c '$cmd'"
 		fi
 	fi
 


### PR DESCRIPTION
On machines where the Java process' primary GID may not match the running GID it's possible to run into issues - specifically:

```
Exception in thread "main" java.io.IOException: well-known file /tmp/.java_pid22933 is not secure: file's group should be the current group (which is 9999) but the group is 999
	at sun.tools.attach.LinuxVirtualMachine.checkPermissions(Native Method)
	at sun.tools.attach.LinuxVirtualMachine.<init>(LinuxVirtualMachine.java:117)
	at sun.tools.attach.LinuxAttachProvider.attachVirtualMachine(LinuxAttachProvider.java:63)
	at com.sun.tools.attach.VirtualMachine.attach(VirtualMachine.java:208)
	at net.virtualvoid.perf.AttachOnce.loadAgent(AttachOnce.java:38)
	at net.virtualvoid.perf.AttachOnce.main(AttachOnce.java:34)
```

Reading the process' running group and using that as a sudo parameter avoids that error. May want to test on a system that doesn't output names (happy to do this - just need a pointer).