### PR TITLE
Encode perf metadata in flamegraph subtitle

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -333,7 +333,16 @@ SVG
 		$x = sprintf "%0.2f", $x;
 		$id =  defined $id ? qq/id="$id"/ : "";
 		$extra ||= "";
-		$self->{svg} .= qq/<text $id x="$x" y="$y" $extra>$str<\/text>\n/;
+		my $content;
+		if (index($str, "\n") != -1) {
+			$content = "";
+			foreach my $line (split "\n", $str) {
+				$content .= qq/<tspan x="$x" dy="12">$line<\/tspan>\n/;
+			}
+		} else {
+			$content = $str;
+		}
+		$self->{svg} .= qq/<text $id x="$x" y="$y" $extra>$content<\/text>\n/;
 	}
 
 	sub svg {
@@ -601,11 +610,16 @@ my $delta = undef;
 my $ignored = 0;
 my $line;
 my $maxdelta = 1;
+my $extrasubtitle = "";
 
 # reverse if needed
 foreach (<>) {
 	chomp;
 	$line = $_;
+	if (/^# /) {
+		$extrasubtitle .= (substr $_, length("# "))."\n";
+		next;
+	}
 	if ($stackreverse) {
 		# there may be an extra samples column for differentials
 		# XXX todo: redo these REs as one. It's repeated below.
@@ -716,6 +730,7 @@ while (my ($id, $node) = each %Node) {
 
 # draw canvas, and embed interactive JavaScript program
 my $imageheight = (($depthmax + 1) * $frameheight) + $ypad1 + $ypad2;
+$subtitletext = $subtitletext ne "" ? $subtitletext."\n".$extrasubtitle : $extrasubtitle;
 $imageheight += $ypad3 if $subtitletext ne "";
 my $titlesize = $fontsize + 5;
 my $im = SVG->new();

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -173,6 +173,17 @@ while (defined($_ = <>)) {
 				last;
 			}
 		}
+
+		print "# perf cmdline: ";
+		print substr $_, length("# cmdline : ");
+	}
+
+	if (/^# sample duration :\s+(\d+(:?\.\d+)?) ms$/) {
+		print "# sampling duration: $1 ms\n";
+	}
+
+	if (/{ sample_period, sample_freq } = (\d+)/) {
+		print "# sampling frequency: $1\n";
 	}
 
 	# skip remaining comments


### PR DESCRIPTION
Here's how it looks:
![screenshot_20200720_025136](https://user-images.githubusercontent.com/8831572/87889045-6cc43a00-ca38-11ea-805c-1d45d853b3ab.png)

This PR uses metadata included in the output of `perf script --header`. Other `stackcollapse` scripts can be modified to output relevant metadata as comments, and `flamegraph.pl` takes all comments and pushes them into the subtitle part of the flamegraph. If the user passes `--subtitle`, it is prepended to the metadata.

Specific display details can be changed, of course; this is just what I generally had in mind. When working with multiple graphs simultaneously, or when sharing graphs with others, it is very useful to have this metadata displayed, and having the displayed data follow a standard instead of being freetext (as happens when manually including this metadata in file names :sweat_smile:)

I used comments (`# ...`) in the input stream of `flamegraph.pl`. As far as I understand the format, it is okay. We can use some other prefix/escaping for comments if there is a chance for colliding with a "real" line.

Closes: #237 

