### PR TITLE
Optional per-method dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,23 +157,28 @@ See the USAGE message (--help) for options:
 
 USAGE: ./flamegraph.pl [options] infile > outfile.svg
 
-	--title       # change title text
-	--width       # width of image (default 1200)
-	--height      # height of each frame (default 16)
-	--minwidth    # omit smaller functions (default 0.1 pixels)
-	--fonttype    # font type (default "Verdana")
-	--fontsize    # font size (default 12)
-	--countname   # count type label (default "samples")
-	--nametype    # name type label (default "Function:")
-	--colors      # set color palette. choices are: hot (default), mem, io,
-	              # wakeup, chain, java, js, perl, red, green, blue, aqua,
-	              # yellow, purple, orange
-	--hash        # colors are keyed by function name hash
-	--cp          # use consistent palette (palette.map)
-	--reverse     # generate stack-reversed flame graph
-	--inverted    # icicle graph
-	--negate      # switch differential hues (blue<->red)
-	--help        # this message
+	--title TEXT     # change title text
+	--subtitle TEXT  # second level title (optional)
+	--width NUM      # width of image (default 1200)
+	--height NUM     # height of each frame (default 16)
+	--minwidth NUM   # omit smaller functions (default 0.1 pixels)
+	--fonttype FONT  # font type (default "Verdana")
+	--fontsize NUM   # font size (default 12)
+	--countname TEXT # count type label (default "samples")
+	--nametype TEXT  # name type label (default "Function:")
+	--colors PALETTE # set color palette. choices are: hot (default), mem,
+	                 # io, wakeup, chain, java, js, perl, red, green, blue,
+	                 # aqua, yellow, purple, orange
+	--bgcolors COLOR # set background colors. gradient choices are yellow
+	                 # (default), blue, green, grey; flat colors use "#rrggbb"
+	--hash           # colors are keyed by function name hash
+	--cp             # use consistent palette (palette.map)
+	--reverse        # generate stack-reversed flame graph
+	--inverted       # icicle graph
+	--flamechart     # produce a flame chart (sort by time, do not merge stacks)
+	--negate         # switch differential hues (blue<->red)
+	--notes TEXT     # add notes comment in SVG (for debugging)
+	--help           # this message
 
 	eg,
 	./flamegraph.pl --title="Flame Graph: malloc()" trace.txt > graph.svg

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -465,6 +465,24 @@ sub color {
 		}
 		# fall-through to color palettes
 	}
+	if (defined $type and $type eq "python") {
+		# Handle annotations (_[j], _[k], ...; which are
+		# accurate), as well as input that lacks any annotations, as
+		# best as possible. Without annotations, we get a little hacky,
+		# and match on a "/" with a ".py", etc.
+		if ($name =~ m:_\[j\]$:) {	# jit annotation
+			$type = "green";
+		} elsif ($name =~ m:/.*\.py.?:) {	# Python (match "/" in path)
+			$type = "green";
+		} elsif ($name =~ m:python:) {	# cpython
+			$type = "yellow";
+		} elsif ($name =~ m:_\[k\]$:) {	# kernel annotation
+			$type = "orange";
+		} else {			# system
+			$type = "red";
+		}
+		# fall-through to color palettes
+	}
 	if (defined $type and $type eq "wakeup") {
 		$type = "aqua";
 		# fall-through to color palettes

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -602,9 +602,11 @@ sub flow {
 			$Tmp{$k}->{delta} += $i == $len_b ? $d : 0;
 		}
 	}
-	$Tmp{"$this->[$len_b];$len_b"}->{own} = $own;
+	if (@$this != 0) {
+		$Tmp{"$this->[$len_b];$len_b"}->{own} = $own;
+	}
 
-        return $this;
+	return $this;
 }
 
 # parse input

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -99,7 +99,7 @@ use open qw(:std :utf8);
 # tunables
 my $encoding;
 my $fonttype = "Verdana";
-my $imagewidth = 1200;          # max width, pixels
+my $imagewidth = 1900;          # max width, pixels
 my $frameheight = 16;           # max height is dynamic
 my $fontsize = 12;              # base text size
 my $fontwidth = 0.59;           # avg width relative to fontsize

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -407,7 +407,7 @@ sub color {
 			$type = "green";
 		} elsif ($name =~ m:_\[i\]$:) {	# inline annotation
 			$type = "aqua";
-		} elsif ($name =~ m:^L?(java|javax|net|org|com|io|sun)/:) {	# Java
+		} elsif ($name =~ m:^L?(java|javax|jdk|net|org|com|io|sun)/:) {	# Java
 			$type = "green";
 		} elsif ($name =~ m:_\[k\]$:) {	# kernel annotation
 			$type = "orange";

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -330,7 +330,7 @@ while (defined($_ = <>)) {
 			#
 			# detect inlined from the @inline array
 			# detect kernel from the module name; eg, frames to parse include:
-			#          ffffffff8103ce3b native_safe_halt ([kernel.kallsyms]) 
+			#          ffffffff8103ce3b native_safe_halt ([kernel.kallsyms])
 			#          8c3453 tcp_sendmsg (/lib/modules/4.3.0-rc1-virtual/build/vmlinux)
 			#          7d8 ipv4_conntrack_local+0x7f8f80b8 ([nf_conntrack_ipv4])
 			# detect jit from the module name; eg:
@@ -340,6 +340,8 @@ while (defined($_ = <>)) {
 			} elsif ($annotate_kernel == 1 && $mod =~ m/(^\[|vmlinux$)/ && $mod !~ /unknown/) {
 				$func .= "_[k]";	# kernel
 			} elsif ($annotate_jit == 1 && $mod =~ m:/tmp/perf-\d+\.map:) {
+				$func .= "_[j]";	# jitted
+			} elsif ($annotate_jit == 1 && $mod =~ m:/jitted-\d+-\d+\.so:) {
 				$func .= "_[j]";	# jitted
 			}
 			push @inline, $func;


### PR DESCRIPTION
The collapsed output now accepts an optional dependencies list at the end of each method in the stack, separated by `|||`.