### PR TITLE
enhancing stackcollapse-perf.pl "--inline" option: caching addr2line and getting rid of '??' in graphs

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -119,9 +119,13 @@ if ($annotate_all) {
 	$annotate_kernel = $annotate_jit = 1;
 }
 
+my %inlineCache;
+
 # for the --inline option
 sub inline {
 	my ($pc, $mod) = @_;
+
+	return $inlineCache{$pc}{$mod} if defined($inlineCache{$pc}{$mod});
 
 	# capture addr2line output
 	my $a2l_output = `addr2line -a $pc -e $mod -i -f -s -C`;
@@ -149,7 +153,15 @@ sub inline {
 		}
 	}
 
-	return join(";", @fullfunc);
+	my $result = join ";" , @fullfunc;
+
+	if (defined($inlineCache{$pc})){
+		$inlineCache{$pc}{$mod}=$result;
+	} else {
+		$inlineCache{$pc} = {$mod => $result};
+	}
+
+	return $result;
 }
 
 my @stack;

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -274,8 +274,14 @@ while (defined($_ = <>)) {
 		$rawfunc =~ s/\+0x[\da-f]+$//;
 
 		if ($show_inline == 1 && $mod !~ m/(perf-\d+.map|kernel\.|\[[^\]]+\])/) {
-			unshift @stack, inline($pc, $mod);
-			next;
+			my $inlineRes = inline($pc, $mod);
+			# - empty result this happens e.g., when $mod does not exist or is a path to a compressed kernel module
+			#   if this happens, the user will see error message from addr2line written to stderr
+			# - if addr2line results in "??" , then it's much more sane to fall back than produce a '??' in graph
+			if($inlineRes ne "" and $inlineRes ne "??" and $inlineRes ne "??:??:0" ) {
+				unshift @stack, inline($pc, $mod);
+				next;
+			}
 		}
 
 		next if $rawfunc =~ /^\(/;		# skip process names

--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -156,7 +156,7 @@ sub inline {
 
 			$nmCache{$mod}=`nm $mod` unless defined $nmCache{$mod};
 
-			if ($nmCache{$mod} =~ /^([0-9a-f]+) . $func$/m) {
+			if ($nmCache{$mod} =~ /^([0-9a-f]+) . \Q$func\E$/m) {
 			   my $base = hex $1;
 				my $newPc = sprintf "0x%x", $base+$addr;
 				my $result = inline($newPc, '', $mod);


### PR DESCRIPTION
This PR solves two issues when collapsing stacks produced by linux perf script with `--inline` option – that is, excessive use of `addr2line` and outputting `;??;` or `;;` in the results.

#### caching addr2line results
`stackcollapse-perf.pl` calls `addr2line` on every single input line. This takes lots of time. The input lines obviously repeat most of the time. So it's a perfect place to add a cache of *module,pc -> resolved addr2line result*. This saves a ton of time:
```
$ # before patches (I lost my patience after about 20 minutes, thus ^C)
$ time perf script -i /tmp/perf_0.data | ~/bin/FlameGraph/stackcollapse-perf.pl --inline &> /dev/null
^C
real    19m29,380s
user    15m5,214s
sys     4m29,142s
$
$ # after patches
$ time perf script -i /tmp/perf_0.data | ~/bin/FlameGraph/stackcollapse-perf.pl --inline &> /dev/null
real    0m53,448s
user    0m39,918s
sys     0m15,196s
```

#### dealing with addr2line failures
Sometimes addr2line produces unhelpful results, such as:
- `??` (literally two question marks) - in my case at some intrinsics, but this can obviously happen in many other cases
- `` (empty result)  - in my case in the output I saw lines such as: 
`addr2line: /lib/modules/5.11.6-1-default/kernel/fs/btrfs/btrfs.ko.xz: file format not recognized`
and this also can be triggered by missing executable among others

This should be avoided, and I think the best is to fall back to printing default symbols.


#### .

(I guess I should have made two separate PRs, but I let it be since both fix the same `--inline` switch)