### PR TITLE
Update stackcollapse-bpftrace to work with book examples

### DIFF
--- a/stackcollapse-bpftrace.pl
+++ b/stackcollapse-bpftrace.pl
@@ -51,15 +51,21 @@ my $in_stack = 0;
 foreach (<>) {
   chomp;
   if (!$in_stack) {
-    if (/^@\[/) {
+    if (/^@\[$/) {
       $in_stack = 1;
+    } elsif (/^@\[,\s(.*)\]: (\d+)/) {
+      print $1 . " $2\n";
     }
   } else {
-    if (m/^\]: (\d+)/) {
-      print join(';', reverse(@stack)) . " $1\n";
+    if (m/^,?\s?(.*)\]: (\d+)/) {
+      if (length $1) {
+        push(@stack, $1);
+      }
+      print join(';', reverse(@stack)) . " $2\n";
       $in_stack = 0;
       @stack = ();
     } else {
+      $_ =~ s/^\s+//;
       push(@stack, $_);
     }
   }


### PR DESCRIPTION
stackcollapse-bpftrace doesn't work for examples in the Systems Performance book when there is a comma in the output. ie:
```
bpftrace -e 't:exceptions:page_fault_user { @[ustack, comm] = count(); }'
```
This change makes the script work for all the following inputs:
```
# Continues to work for the ustack-only format
@[
    line1
    line2
]: 10

# The format the book uses for some bpftrace examples
@[
    line1
    line2
, process]: 10

# When the ustack value is empty
@[, process]: 10
```

I additionally do a left trim to remove the new stack indentation. This is my first time working with Perl, so open to suggestions on how to do this better.