### PR TITLE
Fix trailing spaces after Java color statement

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -410,7 +410,7 @@ sub color {
 		} elsif ($name =~ m:^L?(java|javax|jdk|net|org|com|io|sun)/:) {	# Java
 			$type = "green";
 		} elsif ($name =~ /:::/) {      # Java, typical perf-map-agent method separator
-			$type = "green";	              
+			$type = "green";
 		} elsif ($name =~ /::/) {	# C++
 			$type = "yellow";
 		} elsif ($name =~ m:_\[k\]$:) {	# kernel annotation


### PR DESCRIPTION
Follows-up 88f6cfe8c3cec82d89d785d2f989e5a41fe9b2a6.