### PR TITLE
fix: search should not treat null object as 'null' search term

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -1060,6 +1060,7 @@ my $inc = <<INC;
 	}
 	function search(term) {
 		if (term) currentSearchTerm = term;
+		if (currentSearchTerm === null) return;
 
 		var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
 		var el = document.getElementById("frames").children;


### PR DESCRIPTION
`search()` is invoked in `zoom()` and `unzoom()` without arguments, to restart the search for the new view.       
This uses the global `currentSearchTerm`.     

But if there is no active search, thus `currentSearchTerm` is still `null` as set during initialization in `init()` then the problem is that the search function doesn't exit early and creates a regex:
```js
 var re = new RegExp(currentSearchTerm, ignorecase ? 'i' : '');
```
Which will treat the `null` object the same way as a string of `"null"`, thus searching for strings containing `"null"`

I guess that doesn't usually lead to any matches, thus the wrong behavior is rarely observed. 
But I've come across this problem with a flamegraph that has stacks containing `gsl::not_null` in them. 

This MR just introduces a small change, which will return early from the `search()` function if the `currentSearchTerm` is `null` .  Actually searching for `"null"` is still possible and works as expected.