### PR TITLE
fix: javascript performance issues (slow zoom() unzoom())

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -890,11 +890,15 @@ my $inc = <<INC;
 		}
 
 		t.textContent = txt;
-		// Fit in full text width
-		if (/^ *\$/.test(txt) || t.getSubStringLength(0, txt.length) < w)
+		var sl = t.getSubStringLength(0, txt.length);
+		// check if only whitespace or if we can fit the entire string into width w
+		if (/^ *\$/.test(txt) || sl < w)
 			return;
 
-		for (var x = txt.length - 2; x > 0; x--) {
+		// this isn't perfect, but gives a good starting point
+		// and avoids calling getSubStringLength too often
+		var start = Math.floor((w/sl) * txt.length) - 2
+		for (var x = start; x > 0; x = x-2) {
 			if (t.getSubStringLength(0, x + 2) <= w) {
 				t.textContent = txt.substring(0, x) + "..";
 				return;

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -776,10 +776,15 @@ my $inc = <<INC;
 				if (e.ctrlKey === false) return;
 				e.preventDefault();
 			}
-			if (target.classList.contains("parent")) unzoom();
+			if (target.classList.contains("parent")) unzoom(true);
 			zoom(target);
 			if (!document.querySelector('.parent')) {
-				clearzoom();
+				// we have basically done a clearzoom so clear the url
+				var params = get_params();
+				if (params.x) delete params.x;
+				if (params.y) delete params.y;
+				history.replaceState(null, null, parse_params(params));
+				unzoombtn.classList.add("hide");
 				return;
 			}
 
@@ -897,7 +902,7 @@ my $inc = <<INC;
 
 		// this isn't perfect, but gives a good starting point
 		// and avoids calling getSubStringLength too often
-		var start = Math.floor((w/sl) * txt.length) - 2
+		var start = Math.floor((w/sl) * txt.length);
 		for (var x = start; x > 0; x = x-2) {
 			if (t.getSubStringLength(0, x + 2) <= w) {
 				t.textContent = txt.substring(0, x) + "..";
@@ -1004,14 +1009,14 @@ my $inc = <<INC;
 		}
 		search();
 	}
-	function unzoom() {
+	function unzoom(dont_update_text) {
 		unzoombtn.classList.add("hide");
 		var el = document.getElementById("frames").children;
 		for(var i = 0; i < el.length; i++) {
 			el[i].classList.remove("parent");
 			el[i].classList.remove("hide");
 			zoom_reset(el[i]);
-			update_text(el[i]);
+			if(!dont_update_text) update_text(el[i]);
 		}
 		search();
 	}


### PR DESCRIPTION
If you have a flamegraph with a lot of frames and those frames maybe have long function names (due to e.g. C++ templates, namespaces) then the zooming and especially the zooming out can be really slow.  

Most of the cost is the repetitive call to ` getSubStringLength` to figure out if a string will fit into the width of the box. 

This PR does two things:
- don't update the text of the boxes in the `unzoom()` call before the following `zoom()` to avoid doing the work twice
- Make the actual call of `update_text()` a lot faster by guessing a better starting point, by using:
```js
 var start = Math.floor((w/sl) * txt.length) - 2
```
Where `w` is the width of the box and `sl` the return value of `getSubStringLength`.  This isn't perfect so we still need to iterate a bit afterwards and sometimes the starting point might already be a bit smaller than if we had iterated in small steps, but I've not seen it be dramatically off.  

And the benefits are significant!
I'm currently looking at a profile where the `unzoom()` went from 3s to 100ms -> 30x speedup. TBH, at least to me, that's the difference between usable and unusable zoom functionality. 


