### PR TITLE
stackcollapse-perf: fix flag in example

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -33,7 +33,7 @@
 # The output of "perf script" should include stack traces. If these are missing
 # for you, try manually selecting the perf script output; eg:
 #
-#  perf script -f comm,pid,tid,cpu,time,event,ip,sym,dso,trace | ...
+#  perf script -F comm,pid,tid,cpu,time,event,ip,sym,dso,trace | ...
 #
 # This is also required for the --pid or --tid options, so that the output has
 # both the PID and TID.


### PR DESCRIPTION
Looks like the intent was to pass --fields, not --force.

I was already confused when I started reading the docs for this script, using the wrong option didn't help matters any ;-)