### PR TITLE
stackcollapse-instruments: Update to handle "Deep Copy" format

### DIFF
--- a/stackcollapse-instruments.pl
+++ b/stackcollapse-instruments.pl
@@ -2,8 +2,8 @@
 #
 # stackcollapse-instruments.pl
 #
-# Parses a CSV file containing a call tree as produced by XCode
-# Instruments and produces output suitable for flamegraph.pl.
+# Parses a file containing a call tree as produced by XCode Instruments
+# (Edit > Deep Copy) and produces output suitable for flamegraph.pl.
 #
 # USAGE: ./stackcollapse-instruments.pl infile > outfile
 
@@ -14,13 +14,21 @@ my @stack = ();
 <>;
 foreach (<>) {
 	chomp;
-	/\d+\.\d+ms[^,]+,(\d+(?:\.\d*)?),\s+,(\s*)(.+)/ or die;
-	my $func = $3;
-	my $depth = length ($2);
-	$stack [$depth] = $3;
+	/\d+\.\d+ (?:min|s|ms)\s+\d+\.\d+%\s+(\d+(?:\.\d+)?) (min|s|ms)\t \t(\s*)(.+)/ or die;
+	my $func = $4;
+	my $depth = length ($3);
+	$stack [$depth] = $4;
 	foreach my $i (0 .. $depth - 1) {
 		print $stack [$i];
 		print ";";
 	}
-	print "$func $1\n";
+
+	my $time = 0 + $1;
+	if ($2 eq "min") {
+		$time *= 60*1000;
+	} elsif ($2 eq "s") {
+		$time *= 1000;
+	}
+
+	printf("%s %.0f\n", $func, $time);
 }


### PR DESCRIPTION
Xcode Instruments removed the export option a few years ago (I'm unsure when, but it is definitely not available in Instruments 13.0 onwards).
However, you can still access the data by selecting the top symbol in the call stack and using the Edit > Deep Copy menu item, then pasting into a file. 
This PR updates stackcollapse-instruments.pl to handle the "Deep Copy" format.
