### PR TITLE
Display the text that was searched for when a match occurs.

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -750,13 +750,14 @@ my $inc = <<INC;
 <script type="text/ecmascript">
 <![CDATA[
 	"use strict";
-	var details, searchbtn, unzoombtn, matchedtxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
+	var details, searchbtn, unzoombtn, matchedtxt, searchedFortxt, svg, searching, currentSearchTerm, ignorecase, ignorecaseBtn;
 	function init(evt) {
 		details = document.getElementById("details").firstChild;
 		searchbtn = document.getElementById("search");
 		ignorecaseBtn = document.getElementById("ignorecase");
 		unzoombtn = document.getElementById("unzoom");
 		matchedtxt = document.getElementById("matched");
+		searchedFortxt = document.getElementById("searchedFor");
 		svg = document.getElementsByTagName("svg")[0];
 		searching = 0;
 		currentSearchTerm = null;
@@ -1065,6 +1066,7 @@ my $inc = <<INC;
 			searchbtn.firstChild.nodeValue = "Search"
 			matchedtxt.classList.add("hide");
 			matchedtxt.firstChild.nodeValue = ""
+			searchedFortxt.classList.add("hide");
 		}
 	}
 	function search(term) {
@@ -1145,6 +1147,10 @@ my $inc = <<INC;
 		var pct = 100 * count / maxwidth;
 		if (pct != 100) pct = pct.toFixed(1)
 		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+
+		// Show the text that was searched for.
+		searchedFortxt.classList.remove("hide");
+		searchedFortxt.firstChild.nodeValue = "Searched for: " + currentSearchTerm;
 	}
 ]]>
 </script>
@@ -1158,6 +1164,7 @@ $im->stringTTF("unzoom", $xpad, $fontsize * 2, "Reset Zoom", 'class="hide"');
 $im->stringTTF("search", $imagewidth - $xpad - 100, $fontsize * 2, "Search");
 $im->stringTTF("ignorecase", $imagewidth - $xpad - 16, $fontsize * 2, "ic");
 $im->stringTTF("matched", $imagewidth - $xpad - 100, $imageheight - ($ypad2 / 2), " ");
+$im->stringTTF("searchedFor", $xpad, $imageheight - ($ypad2 / 2), " ");
 
 if ($palette) {
 	read_palette();

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -1067,6 +1067,7 @@ my $inc = <<INC;
 			matchedtxt.classList.add("hide");
 			matchedtxt.firstChild.nodeValue = ""
 			searchedFortxt.classList.add("hide");
+			searchedFortxt.firstChiled.nodeValue = ""
 		}
 	}
 	function search(term) {


### PR DESCRIPTION
The text is displayed in the bottom left corner.

This text will show whenever the "Matched: x%" text is shown.

This can be useful when you're switching between multiple flamegraphs, and you come back to a graph with highlighted bars, but you don't remember what you searched for to highlight those bars.