### PR TITLE
Make coloring deterministic

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -378,6 +378,11 @@ sub namehash {
 	return (1 - $vector / $max)
 }
 
+sub sum_namehash {
+  my $name = shift;
+  return unpack("%32W*", $name);
+}
+
 sub random_namehash {
 	# Generate a random hash for the name string.
 	# This ensures that functions with the same name have the same color,
@@ -385,9 +390,7 @@ sub random_namehash {
 	# needing to set a palette and while preserving the original flamegraph
 	# optic, unlike what happens with --hash.
 	my $name = shift;
-	use Digest::MD5 qw(md5);
-	my $str = substr( md5($name), 0, 4 );
-	my $hash = unpack('L', $str);
+	my $hash = sum_namehash($name);
 	srand($hash);
 	return rand(1)
 }

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -112,6 +112,7 @@ my $nameattrfile;               # file holding function attributes
 my $timemax;                    # (override the) sum of the counts
 my $factor = 1;                 # factor to scale counts by
 my $hash = 0;                   # color by function name
+my $rand = 0;                   # color randomly
 my $palette = 0;                # if we use consistent palettes (default off)
 my %palette_map;                # palette map hash
 my $pal_file = "palette.map";   # palette map file name
@@ -134,7 +135,7 @@ USAGE: $0 [options] infile > outfile.svg\n
 	--subtitle TEXT  # second level title (optional)
 	--width NUM      # width of image (default 1200)
 	--height NUM     # height of each frame (default 16)
-	--minwidth NUM   # omit smaller functions. In pixels or use "%" for 
+	--minwidth NUM   # omit smaller functions. In pixels or use "%" for
 	                 # percentage of time (default 0.1 pixels)
 	--fonttype FONT  # font type (default "Verdana")
 	--fontsize NUM   # font size (default 12)
@@ -146,6 +147,7 @@ USAGE: $0 [options] infile > outfile.svg\n
 	--bgcolors COLOR # set background colors. gradient choices are yellow
 	                 # (default), blue, green, grey; flat colors use "#rrggbb"
 	--hash           # colors are keyed by function name hash
+	--random         # colors are randomly generated
 	--cp             # use consistent palette (palette.map)
 	--reverse        # generate stack-reversed flame graph
 	--inverted       # icicle graph
@@ -177,6 +179,7 @@ GetOptions(
 	'colors=s'    => \$colors,
 	'bgcolors=s'  => \$bgcolors,
 	'hash'        => \$hash,
+	'random'      => \$rand,
 	'cp'          => \$palette,
 	'reverse'     => \$stackreverse,
 	'inverted'    => \$inverted,
@@ -396,6 +399,10 @@ sub color {
 	if ($hash) {
 		$v1 = namehash($name);
 		$v2 = $v3 = namehash(scalar reverse $name);
+	} elsif ($rand) {
+		$v1 = rand(1);
+		$v2 = rand(1);
+		$v3 = rand(1);
 	} else {
 		$v1 = random_namehash($name);
 		$v2 = random_namehash($name);
@@ -435,7 +442,7 @@ sub color {
 		} elsif ($name =~ m:^L?(java|javax|jdk|net|org|com|io|sun)/:) {	# Java
 			$type = "green";
 		} elsif ($name =~ /:::/) {      # Java, typical perf-map-agent method separator
-			$type = "green";	              
+			$type = "green";
 		} elsif ($name =~ /::/) {	# C++
 			$type = "yellow";
 		} elsif ($name =~ m:_\[k\]$:) {	# kernel annotation

--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -364,6 +364,20 @@ sub namehash {
 	return (1 - $vector / $max)
 }
 
+sub random_namehash {
+	# Generate a random hash for the name string.
+	# This ensures that functions with the same name have the same color,
+	# both within a flamegraph and across multiple flamegraphs without
+	# needing to set a palette and while preserving the original flamegraph
+	# optic, unlike what happens with --hash.
+	my $name = shift;
+	use Digest::MD5 qw(md5);
+	my $str = substr( md5($name), 0, 4 );
+	my $hash = unpack('L', $str);
+	srand($hash);
+	return rand(1)
+}
+
 sub color {
 	my ($type, $hash, $name) = @_;
 	my ($v1, $v2, $v3);
@@ -372,9 +386,9 @@ sub color {
 		$v1 = namehash($name);
 		$v2 = $v3 = namehash(scalar reverse $name);
 	} else {
-		$v1 = rand(1);
-		$v2 = rand(1);
-		$v3 = rand(1);
+		$v1 = random_namehash($name);
+		$v2 = random_namehash($name);
+		$v3 = random_namehash($name);
 	}
 
 	# theme palettes


### PR DESCRIPTION
This PR makes the color assigned to each function deterministic both within a flame graph and across flame graphs by using the function name hash as the random seed for the color selection.

This brings two benefits:
a) Multiple occurrences of the same function will have the same color within a flame graph
b) When using two flame graphs to do a before-after comparison of some change, both flame graphs will have identical coloring, making them easier to compare.

Here is an example of flamegraphs from two different performance tests where the coloring makes it easier to track similarities/differences:
![image](https://user-images.githubusercontent.com/31125121/229737070-e5d23cb8-c217-4c15-85f3-8e9cf355e3f0.png)
![image](https://user-images.githubusercontent.com/31125121/229737103-d53aa090-f136-4783-a2d8-f8759fd8c09c.png)

This is a rough version, and I would clean it up and move it behind a flag, update documentation, etc., but wanted to feel out if there is any interest in this first.