### PR TITLE
Fix single-character binary names in stackcollapse-perf

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -242,7 +242,7 @@ while (defined($_ = <>)) {
 	#
 	# event record start
 	#
-	if (/^(\S.+?)\s+(\d+)\/*(\d+)*\s+/) {
+	if (/^(\S.*?)\s+(\d+)\/*(\d+)*\s+/) {
 		# default "perf script" output has TID but not PID
 		# eg, "java 25607 4794564.109216: 1 cycles:"
 		# eg, "java 12688 [002] 6544038.708352: 235 cpu-clock:"


### PR DESCRIPTION
Events raised from programs with comm containing of a single character would previously be handled incorrectly. This could occur, for instance, for programs executing /proc/self/fd/<...> or using fexecve