### PR TITLE
Differential Flame Graph enhancements: total-diff calculation and additional rendering customisation

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -146,7 +146,7 @@ USAGE: $0 [options] infile > outfile.svg\n
 	--nametype TEXT   # name type label (default "Function:")
 	--colors PALETTE  # set color palette. choices are: hot (default), mem,
 	                  # io, wakeup, chain, java, js, perl, red, green, blue,
-	                  # aqua, yellow, purple, orange
+	                  # aqua, yellow, purple, grey, orange
 	--bgcolors COLOR  # set background colors. gradient choices are yellow
 	                  # (default), blue, green, grey; flat colors use "#rrggbb"
 	--fillopacity NUM # fill-opacity for drawn rectangles (SVG attribute)
@@ -259,7 +259,7 @@ if ($bgcolors eq "") {
 		$bgcolors = "green";
 	} elsif ($colors =~ /^(io|wakeup|chain)$/) {
 		$bgcolors = "blue";
-	} elsif ($colors =~ /^(red|green|blue|aqua|yellow|purple|orange)$/) {
+	} elsif ($colors =~ /^(red|green|blue|aqua|yellow|purple|grey|orange)$/) {
 		$bgcolors = "grey";
 	} else {
 		$bgcolors = "yellow";
@@ -547,6 +547,10 @@ sub color {
 		my $x = 190 + int(65 * $v1);
 		my $g = 80 + int(60 * $v1);
 		return "rgb($x,$g,$x)";
+	}
+	if (defined $type and $type eq "grey") {
+		my $x = 100 + int(150 * $v1);
+		return "rgb($x,$x,$x)";
 	}
 	if (defined $type and $type eq "aqua") {
 		my $r = 50 + int(60 * $v1);


### PR DESCRIPTION
**Overview**:

This pull request introduces an opt-in total-diff calculation method for Differential Flame Graphs, complementing the existing self-diff approach. Additionally, it adds two new flags for diff rendering customisation.

TL;DR: see `Demos` section below

**Proposed changes**:

New flags:
- `--totaldiff`: aggregates diff values (i.e. uses total-diff not self-diff) when calculating differential hues
- `--mindeltapc NUM`: min delta (as % of function duration) to use diff hues (allows to reduce noise from insignificant changes)
- `--fillopacity NUM`: fill-opacity for drawn rectangles (SVG attribute; helps with method name readability)

**Self-diff vs Total-diff**:

Self-diff vs total-diff are based on self-time vs total-time. Basic example below:

- **Base Trace** (`f1`: 25%; `f2`: 25%; `f3`: 25%; `f4`: 25%):
```
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f1 20
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f1;getTime 5
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f2 25
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f3 25
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f4 25
```

- **Current Trace** (`f1`: 20%; `f2`: 30%; `f3`: 10%; `f4`: 40%):
```
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f1 20
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f2 30
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f3 10
  Benchmark.measure;PerfettoSdkBenchmark.basic;f0;f4 40
```

Self-diff doesn't highlight the performance gain in `f1` (25% -> 20%), while total-diff captures this. See `Demos` section below for illustration.

**Demos**:

All hosted as interactive demos on https://gielzak.github.io/flamegraph-demos-totaldiff

- **Basic example:**
    - [default (self-diff)](https://gielzak.github.io/flamegraph-demos-totaldiff/01-basic-selfdiff/index.html) vs [total-diff](https://gielzak.github.io/flamegraph-demos-totaldiff/02-basic-totaldiff/index.html)

- **Real code-change:**
    - [default (self-diff)](https://gielzak.github.io/flamegraph-demos-totaldiff/03-real-selfdiff/index.html) vs [total-diff](https://gielzak.github.io/flamegraph-demos-totaldiff/04-real-totaldiff/index.html)
    - [default (no-filter)](https://gielzak.github.io/flamegraph-demos-totaldiff/04-real-totaldiff/index.html) vs [min-delta 0.1%](https://gielzak.github.io/flamegraph-demos-totaldiff/05-real-totaldiff-mindiffpc/index.html)
    - [default (fill-opacity 100%)](https://gielzak.github.io/flamegraph-demos-totaldiff/05-real-totaldiff-mindiffpc/index.html) vs [fill-opacity 65%](https://gielzak.github.io/flamegraph-demos-totaldiff/06-real-totaldiff-mindiffpc-fillopacity/index.html)