### PR TITLE
Remove line number from stackcollapse-wcp output

### DIFF
--- a/stackcollapse-wcp.pl
+++ b/stackcollapse-wcp.pl
@@ -49,7 +49,7 @@ while(<>) {
     # 99.791% ===================================== (17194 samples)
     $samples = $1;
     next;
-  } elsif (m/^\d+: (.*)$/) {
+  } elsif (m/^\d+: (.*) +\(at .*\)$/) {
     # 1: poll__YNjd8fE6xG8CRNwfLnrx0g_2   (at /mnt/sde1/storage/nim-beacon-chain-clean/vendor/nim-chronos/chronos/asyncloop.nim:343)
     my $function = $1;
     if ($current eq "") {


### PR DESCRIPTION
Right now `stackcollapse-wcp.pl` keeps the file and line numbers as part of the function name (so a function is named `main (at main.cpp:50` for example)

This causes functions to be registered multiple times (see screenshots)

I'm not 100% sure, but I'd say that this is not how flame graphs work, and not a wanted behavior ?

Without patch:
![without_patch](https://github.com/brendangregg/FlameGraph/assets/42669835/f464213c-9803-4eb8-a6d0-046be5f51c28)

With patch
![with_patch](https://github.com/brendangregg/FlameGraph/assets/42669835/381e0df0-a3f8-45bc-8051-fbf30977f081)


