### PR TITLE
stackcollapse-perf.pl: Add an option to aggregate comm across cpus.

### DIFF
--- a/stackcollapse-perf.pl
+++ b/stackcollapse-perf.pl
@@ -88,6 +88,7 @@ my $event_warning = 0;	  # if we printed a warning for the event
 
 my $show_inline = 0;
 my $show_context = 0;
+my $aggregate_comm = 0;   # replace '/<number>' in input process names with '/all'
 
 my $srcline_in_input = 0; # if there are extra lines with source location (perf script -F+srcline)
 GetOptions('inline' => \$show_inline,
@@ -99,7 +100,8 @@ GetOptions('inline' => \$show_inline,
            'all' => \$annotate_all,
            'tid' => \$include_tid,
            'addrs' => \$include_addrs,
-           'event-filter=s' => \$event_filter)
+           'event-filter=s' => \$event_filter,
+           'aggregate-comm' => \$aggregate_comm)
 or die <<USAGE_END;
 USAGE: $0 [options] infile > outfile\n
 	--pid		# include PID with process names [1]
@@ -111,7 +113,8 @@ USAGE: $0 [options] infile > outfile\n
 	--context	# adds source context to --inline
 	--srcline	# parses output of 'perf script -F+srcline' and adds source context
 	--addrs		# include raw addresses where symbols can't be found
-	--event-filter=EVENT	# event name filter\n
+	--event-filter=EVENT	# event name filter
+	--aggregate-comm        # replace '/<number>' in input process names with '/all'\n
 [1] perf script must emit both PID and TIDs for these to work; eg, Linux < 4.1:
 	perf script -f comm,pid,tid,cpu,time,event,ip,sym,dso,trace
     for Linux >= 4.1:
@@ -255,6 +258,12 @@ while (defined($_ = <>)) {
 		if (not $tid) {
 			$tid = $pid;
 			$pid = "?";
+		}
+		if ($aggregate_comm) {
+			# Replace per-cpu suffix in process names with '/all'.
+			# This allows aggregation across multiple CPUs.
+			# ksoftirqd/156 -> ksoftirqd/all
+			$comm =~ s/\/\d+/\/all/g;
 		}
 
 		if (/:\s*(\d+)*\s+(\S+):\s*$/) {


### PR DESCRIPTION
Samples produced by perf record can include process names that contain the cpu number in them. For example 'ksoftirqd/32', 'migration/16', etc.

Introduce an option called 'aggregate-comm' for replacing the numerical part with '/all' such that the stacks could be combined. This makes flamegraphs for perf records captured on many cpus more legible.