### PR TITLE
fix the error "The charnum provided (0) is greater than or equal to the maximum bound (0)" reported by getSubStringLength function

### DIFF
--- a/flamegraph.pl
+++ b/flamegraph.pl
@@ -943,9 +943,13 @@ my $inc = <<INC;
 		}
 
 		t.textContent = txt;
+
+		if (/^ *\$/.test(txt))
+			return;
+
 		var sl = t.getSubStringLength(0, txt.length);
 		// check if only whitespace or if we can fit the entire string into width w
-		if (/^ *\$/.test(txt) || sl < w)
+		if (sl < w)
 			return;
 
 		// this isn't perfect, but gives a good starting point


### PR DESCRIPTION
Hi, I use flamegraph.pl to generate svg, when I open it with chrome, I got the error  "The charnum provided (0) is greater than or equal to the maximum bound (0)" reported by getSubStringLength function in https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl#L946 

so, I write a demo to test it, got the error
```
<svg width="1200" height="1526" xmlns="http://www.w3.org/2000/svg">
    <text id="myText" x="10" y="50" font-family="Verdana" font-size="35">Hello Svg!</text>
    <text id="myText2" x="0" y="100" font-family="Verdana" font-size="35"> F </text>
    <text id="myText3" x="0" y="200" font-family="Verdana" font-size="35">   </text>


    <script>
        console.log("==== start");
        const t1 = document.getElementById('myText');
        console.log(`t1 length: ${t1.textContent.length}, getNumberOfChars: ${t1.getNumberOfChars()}, trim length: ${t1.textContent.trim().length}`);
        const substringLength_1 = t1.getSubStringLength(0, 6);
        console.log(`t1 substr0-6 px is: ${substringLength_1}px`);
        const substringLength = t1.getSubStringLength(0, 7);
        console.log(`t1 substr0-7 px is: ${substringLength}px`);

        console.log("==== ");
        const t2 = document.getElementById('myText2');
        console.log(`t2 length: ${t2.textContent.length}, getNumberOfChars: ${t2.getNumberOfChars()}, trim length: ${t2.textContent.trim().length}`);
        const substringLength_2 = t2.getSubStringLength(0, 1);
        console.log(`t2 substr0-1 px is: ${substringLength_2}px`);

        console.log("==== ");
        const t3 = document.getElementById('myText3');
        console.log(`t3 length: ${t3.textContent.length}, getNumberOfChars: ${t3.getNumberOfChars()}, trim length: ${t3.textContent.trim().length}`);
        <!-- The following will report an error,
             need to judge whether the string after removing the leading and trailing spaces is 0.
             Does this mean that the getSubStringLength function will determine whether it is an empty string?
        -->
        const substringLength_3 = t3.getSubStringLength(0, 1);
        console.log(`t3 substr0-1 px is: ${substringLength_3}px`);

        console.log("==== end");
    </script>
</svg>
```
<img width="1692" alt="image" src="https://github.com/user-attachments/assets/298ce0ba-647f-41e7-ab8c-3950bd99746c">

The getNumberOfChars function gets the length of the string after removing spaces.  You can refer to https://chromium.googlesource.com/chromium/blink/+/refs/heads/main/Source/core/svg/SVGTextContentElement.cpp#104