### PR TITLE
Fix stackcollapse regex for new MacOs Instruments trace format

### DIFF
--- a/stackcollapse-instruments.pl
+++ b/stackcollapse-instruments.pl
@@ -14,7 +14,7 @@ my @stack = ();
 <>;
 foreach (<>) {
 	chomp;
-	/\d+\.\d+ (?:min|s|ms)\s+\d+\.\d+%\s+(\d+(?:\.\d+)?) (min|s|ms)\t \t(\s*)(.+)/ or die;
+	/\d+\.\d+ (?:min|s|ms)\s+\S+\s+(\d+(?:\.\d+)?) (min|s|ms)\t (\s*)(.+)/ or die "Error parsing line: $_\n";
 	my $func = $4;
 	my $depth = length ($3);
 	$stack [$depth] = $4;


### PR DESCRIPTION
The regex in the stackcollapse script for MacOs instruments needs changing I believe. At the least old one didn't work for me anymore. See #6 .